### PR TITLE
Relevance #5: Applied-job dimmed lane via content_hash

### DIFF
--- a/backend/export_data.py
+++ b/backend/export_data.py
@@ -38,9 +38,25 @@ def export(db_path: str = DB_PATH, output_path: str = None, cycle_counter: int =
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
 
-    rows = conn.execute(
-        "SELECT * FROM jobs WHERE is_active = 1 ORDER BY relevance_score DESC LIMIT 500"
-    ).fetchall()
+    # LEFT JOIN applications so the dashboard knows which jobs the user already
+    # applied to. Match by external_id OR content_hash — content_hash catches
+    # the case where Greenhouse/Lever republishes the same req with a new ID.
+    # COALESCE picks the freshest applied_at when both legs of the OR hit.
+    rows = conn.execute("""
+        SELECT j.*,
+               MAX(a.status)     AS application_status,
+               MAX(a.applied_at) AS application_applied_at
+        FROM jobs j
+        LEFT JOIN applications a
+               ON (a.external_id = j.external_id
+                   OR (a.content_hash IS NOT NULL
+                       AND a.content_hash = j.content_hash))
+              AND a.status != 'removed'
+        WHERE j.is_active = 1
+        GROUP BY j.id
+        ORDER BY j.relevance_score DESC
+        LIMIT 500
+    """).fetchall()
 
     jobs = []
     for r in rows:

--- a/backend/export_data.py
+++ b/backend/export_data.py
@@ -41,11 +41,18 @@ def export(db_path: str = DB_PATH, output_path: str = None, cycle_counter: int =
     # LEFT JOIN applications so the dashboard knows which jobs the user already
     # applied to. Match by external_id OR content_hash — content_hash catches
     # the case where Greenhouse/Lever republishes the same req with a new ID.
-    # COALESCE picks the freshest applied_at when both legs of the OR hit.
+    # Priority-based aggregation (applied > saved > others) so a job matched
+    # by BOTH a 'saved' row (old external_id) and an 'applied' row (content_hash)
+    # surfaces as 'applied' — MAX() over the status string sorts 'saved' first
+    # lexicographically, which would silently defeat the dedup.
     rows = conn.execute("""
         SELECT j.*,
-               MAX(a.status)     AS application_status,
-               MAX(a.applied_at) AS application_applied_at
+               CASE
+                 WHEN SUM(CASE WHEN a.status = 'applied' THEN 1 ELSE 0 END) > 0 THEN 'applied'
+                 WHEN SUM(CASE WHEN a.status = 'saved'   THEN 1 ELSE 0 END) > 0 THEN 'saved'
+                 ELSE NULL
+               END AS application_status,
+               MAX(CASE WHEN a.status = 'applied' THEN a.applied_at END) AS application_applied_at
         FROM jobs j
         LEFT JOIN applications a
                ON (a.external_id = j.external_id

--- a/backend/server.py
+++ b/backend/server.py
@@ -435,12 +435,23 @@ def api_save_application():
             existing["applied_at"] if existing else None
         ) if existing else None
 
+        # Look up content_hash from the job row so applied-job dedup survives
+        # external_id churn (Greenhouse/Lever req republish).
+        content_hash = None
+        if new_status == "applied":
+            job_row = conn.execute(
+                "SELECT content_hash FROM jobs WHERE external_id = ?", (ext_id,)
+            ).fetchone()
+            if job_row and job_row["content_hash"]:
+                content_hash = job_row["content_hash"]
+
         if existing:
             conn.execute("""
                 UPDATE applications SET
                     status = ?, notes = COALESCE(?, notes),
                     resume_version = COALESCE(?, resume_version),
                     applied_at = COALESCE(?, applied_at),
+                    content_hash = COALESCE(?, content_hash),
                     updated_at = ?
                 WHERE external_id = ?
             """, (
@@ -448,6 +459,7 @@ def api_save_application():
                 data.get("notes"),
                 data.get("resume_version"),
                 now if new_status == "applied" else None,
+                content_hash,
                 now, ext_id,
             ))
             action = "updated"
@@ -456,8 +468,8 @@ def api_save_application():
                 INSERT INTO applications
                     (external_id, title, company, url, status, relevance_score,
                      salary_min, salary_max, location, notes, resume_version,
-                     saved_at, applied_at, updated_at)
-                VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                     saved_at, applied_at, updated_at, content_hash)
+                VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
             """, (
                 ext_id,
                 data.get("title", ""),
@@ -473,6 +485,7 @@ def api_save_application():
                 now,
                 now if new_status == "applied" else None,
                 now,
+                content_hash,
             ))
             action = "saved"
 
@@ -516,8 +529,22 @@ def patch_application(ext_id):
     if updates.get("status") == "applied":
         updates["applied_at"] = datetime.now(timezone.utc).isoformat()
     updates["updated_at"] = datetime.now(timezone.utc).isoformat()
+    # When transitioning to 'applied', pin the job's content_hash onto the
+    # application row so the export-side dedup still catches it after the
+    # underlying req gets republished with a new external_id.
+    if updates.get("status") == "applied":
+        try:
+            conn = get_conn(DB_PATH)
+            row = conn.execute(
+                "SELECT content_hash FROM jobs WHERE external_id = ?", (ext_id,)
+            ).fetchone()
+            conn.close()
+            if row and row["content_hash"]:
+                updates["content_hash"] = row["content_hash"]
+        except Exception as e:
+            log.warning("content_hash lookup failed for %s: %s", ext_id, e)
     # Build SET clause from KNOWN-SAFE column names only
-    SAFE_COLS = {"status", "notes", "resume_version", "applied_at", "updated_at"}
+    SAFE_COLS = {"status", "notes", "resume_version", "applied_at", "updated_at", "content_hash"}
     set_parts = [f"{k} = ?" for k in updates if k in SAFE_COLS]
     values = [v for k, v in updates.items() if k in SAFE_COLS] + [ext_id]
     try:

--- a/backend/server.py
+++ b/backend/server.py
@@ -529,26 +529,21 @@ def patch_application(ext_id):
     if updates.get("status") == "applied":
         updates["applied_at"] = datetime.now(timezone.utc).isoformat()
     updates["updated_at"] = datetime.now(timezone.utc).isoformat()
-    # When transitioning to 'applied', pin the job's content_hash onto the
-    # application row so the export-side dedup still catches it after the
-    # underlying req gets republished with a new external_id.
-    if updates.get("status") == "applied":
-        try:
-            conn = get_conn(DB_PATH)
-            row = conn.execute(
-                "SELECT content_hash FROM jobs WHERE external_id = ?", (ext_id,)
-            ).fetchone()
-            conn.close()
-            if row and row["content_hash"]:
-                updates["content_hash"] = row["content_hash"]
-        except Exception as e:
-            log.warning("content_hash lookup failed for %s: %s", ext_id, e)
-    # Build SET clause from KNOWN-SAFE column names only
     SAFE_COLS = {"status", "notes", "resume_version", "applied_at", "updated_at", "content_hash"}
-    set_parts = [f"{k} = ?" for k in updates if k in SAFE_COLS]
-    values = [v for k, v in updates.items() if k in SAFE_COLS] + [ext_id]
     try:
         conn = get_conn(DB_PATH)
+        # When transitioning to 'applied', pin the job's content_hash onto the
+        # application row so export-side dedup still catches it after the
+        # underlying req gets republished with a new external_id. A manual
+        # application with no matching job row simply leaves content_hash NULL.
+        if updates.get("status") == "applied":
+            job_row = conn.execute(
+                "SELECT content_hash FROM jobs WHERE external_id = ?", (ext_id,)
+            ).fetchone()
+            if job_row and job_row["content_hash"]:
+                updates["content_hash"] = job_row["content_hash"]
+        set_parts = [f"{k} = ?" for k in updates if k in SAFE_COLS]
+        values = [v for k, v in updates.items() if k in SAFE_COLS] + [ext_id]
         conn.execute(
             f"UPDATE applications SET {', '.join(set_parts)} WHERE external_id = ?",
             values

--- a/backend/storage/db.py
+++ b/backend/storage/db.py
@@ -2,6 +2,7 @@
 SQLite storage — persists scraped + scored jobs with deduplication.
 """
 
+import hashlib
 import json
 import sqlite3
 import logging
@@ -11,6 +12,14 @@ from datetime import datetime, timezone
 log = logging.getLogger(__name__)
 
 DB_PATH = os.environ.get("DB_PATH", os.path.join(os.path.dirname(__file__), "..", "jobscout.db"))
+
+
+def compute_content_hash(title, company, salary_max, description):
+    """Stable identity for a job that survives external_id churn (Greenhouse/Lever
+    re-publish). Title+company+salary+leading description are what a human would
+    recognize as 'the same job'."""
+    payload = f"{(title or '').lower().strip()}|{(company or '').lower().strip()}|{salary_max or 0}|{(description or '')[:200]}"
+    return hashlib.sha256(payload.encode('utf-8')).hexdigest()
 
 
 def get_conn(db_path: str = DB_PATH) -> sqlite3.Connection:
@@ -109,6 +118,22 @@ def init_db(db_path: str = DB_PATH):
         conn.commit()
     except Exception:
         pass  # Column already exists — safe to ignore
+    # content_hash columns enable applied-job dedup that survives external_id churn.
+    for ddl in (
+        "ALTER TABLE jobs ADD COLUMN content_hash TEXT",
+        "ALTER TABLE applications ADD COLUMN content_hash TEXT",
+    ):
+        try:
+            conn.execute(ddl)
+            conn.commit()
+        except Exception:
+            pass  # Column already exists — safe to ignore
+    try:
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_app_content_hash ON applications(content_hash)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_content_hash ON jobs(content_hash)")
+        conn.commit()
+    except Exception:
+        pass
     conn.close()
     log.info("Database initialized at %s", db_path)
 
@@ -119,6 +144,10 @@ def upsert_job(conn: sqlite3.Connection, job: dict) -> str:
     Deduplicates by external_id.
     """
     now = datetime.now(timezone.utc).isoformat()
+    content_hash = compute_content_hash(
+        job.get("title"), job.get("company"),
+        job.get("salary_max", 0), job.get("description"),
+    )
 
     existing = conn.execute(
         "SELECT id, relevance_score, last_seen_at FROM jobs WHERE external_id = ?",
@@ -131,8 +160,9 @@ def upsert_job(conn: sqlite3.Connection, job: dict) -> str:
                 external_id, title, company, location, department,
                 description, url, ats, is_remote, posted_at,
                 salary_min, salary_max, relevance_score, matched_skills,
-                sponsorship, first_seen_at, last_seen_at, is_active, tier
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?)
+                sponsorship, first_seen_at, last_seen_at, is_active, tier,
+                content_hash
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
         """, (
             job["external_id"], job["title"], job["company"],
             job.get("location", ""), job.get("department", ""),
@@ -145,6 +175,7 @@ def upsert_job(conn: sqlite3.Connection, job: dict) -> str:
             int(job.get("sponsorship", False)),
             now, now,
             job.get("tier", "tier1"),
+            content_hash,
         ))
         return "new"
     else:
@@ -156,7 +187,7 @@ def upsert_job(conn: sqlite3.Connection, job: dict) -> str:
                 salary_min = ?, salary_max = ?,
                 relevance_score = ?, matched_skills = ?,
                 sponsorship = ?, last_seen_at = ?, is_active = 1,
-                tier = ?
+                tier = ?, content_hash = ?
             WHERE external_id = ?
         """, (
             job["title"], job.get("location", ""), job.get("department", ""),
@@ -166,7 +197,7 @@ def upsert_job(conn: sqlite3.Connection, job: dict) -> str:
             job.get("relevance_score", 0.0),
             json.dumps(job.get("matched_skills", [])),
             int(job.get("sponsorship", False)),
-            now, job.get("tier", "tier1"), job["external_id"],
+            now, job.get("tier", "tier1"), content_hash, job["external_id"],
         ))
         return "updated"
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -908,20 +908,7 @@ export default function App() {
                       <div style={{flex:1,minWidth:0}}>
                         <div style={{display:"flex",alignItems:"center",gap:8,marginBottom:5,flexWrap:"wrap"}}>
                           <span style={{fontSize:17,fontWeight:700,color:t.tx,fontFamily:"'Playfair Display',serif"}}>{j.title}</span>
-                          {isApplied && (
-                            <span style={{
-                              background:ST_COLOR.applied,
-                              color:'#fff',
-                              fontSize:'10px',
-                              fontWeight:'700',
-                              padding:'2px 7px',
-                              borderRadius:'4px',
-                              letterSpacing:'0.4px',
-                              textTransform:'uppercase',
-                            }}>
-                              ✓ Applied
-                            </span>
-                          )}
+                          {isApplied && <Pill ch={ST_LABEL.applied} c={ST_COLOR.applied} t={t}/>}
                           <Pill ch={catLbl} c={t.bl} t={t}/>
                           <Pill ch={`${ats.i} ${ats.l}`} c={ats.c} t={t}/>
                         </div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -694,6 +694,14 @@ export default function App() {
         const bScore = (b.relevance_score||0) + (isDreamCo(b.company)?0.06:0)
                                                + (isTargetRoleFn(b.title)?0.03:0)
                                                + (isSeniorFn(b.title)?0.01:0);
+        // Within a 0.05-wide score band, applied jobs drop to the bottom so
+        // the user's eye lands on fresh roles first without losing context.
+        const aBand = Math.floor(aScore * 20);
+        const bBand = Math.floor(bScore * 20);
+        if (aBand !== bBand) return bBand - aBand;
+        const aApplied = a.application_status === 'applied' ? 1 : 0;
+        const bApplied = b.application_status === 'applied' ? 1 : 0;
+        if (aApplied !== bApplied) return aApplied - bApplied;
         return bScore - aScore;
       });
     }
@@ -890,15 +898,30 @@ export default function App() {
               const sc=j.relevance_score||0, open=xJ===j.external_id;
               const ats=ATS_META[j.ats]||ATS_META.unknown;
               const catLbl=ROLE_CATS.find(r=>r.id===j._cat)?.label||"Other";
+              const isApplied = j.application_status === 'applied';
               return (
                 <div key={j.external_id} onClick={()=>setXJ(open?null:j.external_id)}
-                  style={{background:t.cd,borderRadius:12,border:`1px solid ${t.bd}`,overflow:"hidden",cursor:"pointer",transition:"all .2s",boxShadow:open?t.sh:t.shS}}>
+                  style={{background:t.cd,borderRadius:12,border:`1px solid ${t.bd}`,overflow:"hidden",cursor:"pointer",transition:"all .2s",boxShadow:open?t.sh:t.shS,opacity:isApplied?0.45:1}}>
                   <div className="job-card-top" style={{padding:"16px 20px",display:"flex",justifyContent:"space-between",alignItems:"center",gap:12}}>
                     <div style={{display:"flex",alignItems:"center",gap:14,flex:1,minWidth:0}}>
                       <LogoImg name={j.company} size={40} t={t}/>
                       <div style={{flex:1,minWidth:0}}>
                         <div style={{display:"flex",alignItems:"center",gap:8,marginBottom:5,flexWrap:"wrap"}}>
                           <span style={{fontSize:17,fontWeight:700,color:t.tx,fontFamily:"'Playfair Display',serif"}}>{j.title}</span>
+                          {isApplied && (
+                            <span style={{
+                              background:ST_COLOR.applied,
+                              color:'#fff',
+                              fontSize:'10px',
+                              fontWeight:'700',
+                              padding:'2px 7px',
+                              borderRadius:'4px',
+                              letterSpacing:'0.4px',
+                              textTransform:'uppercase',
+                            }}>
+                              ✓ Applied
+                            </span>
+                          )}
                           <Pill ch={catLbl} c={t.bl} t={t}/>
                           <Pill ch={`${ats.i} ${ats.l}`} c={ats.c} t={t}/>
                         </div>


### PR DESCRIPTION
## Summary
- Applied jobs were reappearing in the main feed because `backend/export_data.py` never JOINed the `applications` table. This PR LEFT-JOINs on `external_id` **OR** `content_hash` so dedup survives Greenhouse/Lever req-republish, then dims and pushes the matched cards to the bottom of their 0.05 score band on the dashboard.
- `content_hash = sha256(title|company|salary_max|description[:200])` is computed in `upsert_job` and pinned onto the `applications` row at the moment status flips to `applied` (both `POST` and `PATCH` paths).
- Frontend: applied jobs render at `opacity: 0.45` with a `✓ Applied` pill next to the title and drop to the bottom of their score band so the eye lands on fresh roles first.

Closes #5.

## Verify steps
```bash
# Backend smoke (creates temp DB, simulates ATS republish + save→apply race)
cd backend
python -c "from export_data import export; d=export(); print('with app_status:', sum(1 for j in d['jobs'] if j.get('application_status')))"
python -m py_compile storage/db.py server.py export_data.py

# Frontend build
cd ../frontend && npm install --silent && npm run build
```

Also run the end-to-end smoke from the commit message of `2e281c6` — same job upserted twice with different `external_id` but identical content correctly resolves to `application_status='applied'` on both rows via the content_hash JOIN.

## Self-critique findings (5 parallel agents)

| Agent | Finding | Resolution |
|---|---|---|
| A · Sanity | `MAX(a.status)` returns `'saved'` lexicographically over `'applied'` — silently defeats dedup for the common save-then-apply flow. | **Fixed** in `export_data.py`: priority-based `CASE WHEN SUM(... = 'applied') > 0 THEN 'applied' WHEN SUM(... = 'saved') > 0 THEN 'saved' ELSE NULL END`. Re-verified with both rows returning `applied`. |
| B · Production | (1) 412 existing rows have `content_hash=NULL` until next scrape; (2) PATCH split-connection has no transactional guarantee; (3) ALTER TABLE re-run safety. | (1) **Justified, not fixed** — bounded and self-healing on the next scrape cycle (~5 min). SQLite `NULL = NULL` evaluates to NULL (not true), so the OR-leg never produces false-positive joins on the NULL rows. (2) **Fixed** by consolidating into a single conn. (3) Verified safe — `try/except pass` around `ALTER`, `CREATE INDEX IF NOT EXISTS` is idempotent. |
| C · Architecture | The new `✓ Applied` badge bypassed the existing `<Pill>` component and `ST_LABEL.applied` / `ST_COLOR.applied` constants. | **Fixed** in `App.jsx`: now renders `<Pill ch={ST_LABEL.applied} c={ST_COLOR.applied} t={t}/>`, matching the adjacent category and ATS pills. |
| D · Performance | EXPLAIN QUERY PLAN confirms SQLite uses `MULTI-INDEX OR` with both `idx_applications_extid` and the new `idx_app_content_hash`. ~800 b-tree probes at 412 rows. sha256 cost on every upsert: 0.71 ms / 412 rows. | **No change needed** — ship it. |
| E · Rollback | A clean `git revert 2e281c6 13e5eee` is safe. Orphan `content_hash` columns are inert (all INSERTs use explicit column lists). Frontend tolerates missing `application_status` via `undefined === 'applied' → false`. HIGH MATCH percentile math is invariant (LEFT JOIN + GROUP BY preserves the `WHERE is_active=1` row count). | **Documented** — no migration rollback script needed. |

## What this does NOT change
- HIGH MATCH percentile threshold logic in `export_data.py` (the Phase A work) — confirmed by Agent E that `score_pool` and `quantiles(..., n=10)[8]` see the same row set.
- Existing PLATINUM badge / tier scoring.
- `.claude/settings.local.json`, `frontend/public/api-data.json`, `resume.md`, `specs/README.md` (per spec).


---
_Generated by [Claude Code](https://claude.ai/code/session_014Fw6Gg5UQXMGdurhJto2Ps)_