### PR TITLE
Relevance #6: Hybrid recency filter with cycle-absence inference

### DIFF
--- a/backend/export_data.py
+++ b/backend/export_data.py
@@ -4,6 +4,7 @@ Called after every scrape cycle.
 """
 
 import json
+import re
 import sqlite3
 import os
 import logging
@@ -12,6 +13,26 @@ from collections import Counter
 from statistics import quantiles
 
 log = logging.getLogger(__name__)
+
+# Matches a naive ISO-8601 timestamp emitted by greenhouse.py / ashby.py /
+# bamboohr.py (they slice the source ATS string with `[:19]`, dropping any
+# trailing Z/offset). The frontend's `new Date(str)` parses such strings as
+# LOCAL time per ECMAScript, which mis-ages jobs by up to a full day for
+# non-UTC users. We pin them to UTC here so the dashboard sees one timezone.
+_NAIVE_ISO_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$")
+
+
+def _normalize_to_utc(s: str) -> str:
+    """Append +00:00 to a naive ISO timestamp; pass-through anything else.
+
+    A string with an existing offset or `Z` is left untouched. Empty / non-ISO
+    strings (e.g. legacy `YYYY-MM-DD HH:MM:SS` rows from very old data) are
+    returned as-is — they were already broken for `Date()` parsing and the
+    frontend treats them as null-age (passes the 30-day cap, no decay).
+    """
+    if s and _NAIVE_ISO_RE.match(s):
+        return s + "+00:00"
+    return s
 
 DB_PATH = os.environ.get("DB_PATH", os.path.join(os.path.dirname(__file__), "jobscout.db"))
 DEFAULT_OUTPUT = os.path.join(os.path.dirname(__file__), "..", "frontend", "public", "api-data.json")
@@ -70,6 +91,15 @@ def export(db_path: str = DB_PATH, output_path: str = None, cycle_counter: int =
         j = dict(r)
         if isinstance(j.get("matched_skills"), str):
             j["matched_skills"] = _parse_skills(j["matched_skills"])
+        # Single age signal the frontend consumes. posted_at is preferred (it's
+        # the ATS-reported date) but is missing for Playwright targets and weak
+        # for Workday. first_seen_at is our discovery timestamp — always set, so
+        # it bounds the worst-case age estimate at "first time JobScout saw it".
+        # Naive timestamps from greenhouse/ashby/bamboohr get pinned to UTC here
+        # so the frontend's Date() parser doesn't reinterpret them as local time.
+        posted = (j.get("posted_at") or "").strip()
+        first_seen = (j.get("first_seen_at") or "").strip()
+        j["effective_date"] = _normalize_to_utc(posted if posted else first_seen)
         jobs.append(j)
 
     total = len(jobs)

--- a/backend/main.py
+++ b/backend/main.py
@@ -29,6 +29,7 @@ from config.profile import PROFILE
 from core.relevance import RelevanceEngine
 from storage.db import (
     init_db, get_conn, upsert_job, mark_stale_jobs,
+    increment_cycles_missing,
     start_run, finish_run, get_stats,
 )
 from scrapers.utils import scrape_with_retry, parse_salary
@@ -104,6 +105,15 @@ def run_scrape(db_path: str, mode: str = "full", delay: float = 0.3) -> dict:
         "companies": 0, "found": 0, "new": 0,
         "updated": 0, "errors": 0, "skipped": 0, "relevant": 0,
     }
+    # external_ids the scraper actually pulled THIS cycle, regardless of whether
+    # they passed our score filter. Drives cycle-absence inference
+    # (see increment_cycles_missing). Filtering would defeat the purpose:
+    # a still-listed job that dipped below threshold shouldn't be marked missing.
+    seen_external_ids: set[str] = set()
+    # Companies whose scrapers actually ran. Tier 2/3 only run every Nth cycle
+    # (see config.companies.get_batch), so jobs from other companies must be
+    # excluded from the absence penalty.
+    scraped_companies: set[str] = set()
 
     log.info("═══ %s cycle %d — %d companies of %d total ═══",
              mode.upper(), cycle, len(companies), TOTAL_COMPANIES)
@@ -116,6 +126,7 @@ def run_scrape(db_path: str, mode: str = "full", delay: float = 0.3) -> dict:
             continue
 
         stats["companies"] += 1
+        scraped_companies.add(company["name"])
         co_relevant = 0
 
         jobs_from_co = scrape_with_retry(
@@ -124,6 +135,9 @@ def run_scrape(db_path: str, mode: str = "full", delay: float = 0.3) -> dict:
         )
         for raw_job in jobs_from_co:
             stats["found"] += 1
+            ext_id = raw_job.get("external_id")
+            if ext_id:
+                seen_external_ids.add(ext_id)
             if not engine.is_relevant_title(raw_job.get("title", "")):
                 stats["skipped"] += 1
                 continue
@@ -167,10 +181,20 @@ def run_scrape(db_path: str, mode: str = "full", delay: float = 0.3) -> dict:
     conn.commit()
 
     # Playwright scrapers (quant/HFT firms with custom portals)
+    playwright_ran = False
     try:
-        from scrapers.playwright_scraper import scrape_all_playwright
+        from scrapers.playwright_scraper import scrape_all_playwright, PLAYWRIGHT_TARGETS
         pw_jobs = scrape_all_playwright()
+        playwright_ran = True
+        # Playwright targets aren't gated by tier rotation — they all run when
+        # playwright is available, so include their company names in the
+        # absence-eligibility set even if pw_jobs is empty.
+        for t in PLAYWRIGHT_TARGETS:
+            scraped_companies.add(t.get("name", ""))
         for raw_job in pw_jobs:
+            ext_id = raw_job.get("external_id")
+            if ext_id:
+                seen_external_ids.add(ext_id)
             # Mirror the title filter from the classical ATS path so Playwright
             # jobs with title-only descriptions can't pass on tier boost alone.
             if not engine.is_relevant_title(raw_job.get("title", "")):
@@ -196,6 +220,19 @@ def run_scrape(db_path: str, mode: str = "full", delay: float = 0.3) -> dict:
         log.info("Playwright: %d jobs processed", len(pw_jobs))
     except Exception as e:
         log.warning("Playwright scrape skipped (playwright may not be installed): %s", e)
+
+    # Cycle-absence inference — runs AFTER all scrapers so seen_external_ids
+    # is complete. If playwright didn't run, exclude its targets from eligibility
+    # so we don't penalize jobs the scraper couldn't possibly observe this cycle.
+    if not playwright_ran:
+        try:
+            from scrapers.playwright_scraper import PLAYWRIGHT_TARGETS
+            for t in PLAYWRIGHT_TARGETS:
+                scraped_companies.discard(t.get("name", ""))
+        except ImportError:
+            pass
+    increment_cycles_missing(conn, seen_external_ids, scraped_companies)
+    conn.commit()
 
     finish_run(conn, run_id, stats)
     conn.close()

--- a/backend/scrapers/playwright_scraper.py
+++ b/backend/scrapers/playwright_scraper.py
@@ -13,6 +13,8 @@ import logging
 import re
 from typing import Generator
 
+from scrapers.utils import parse_posted_date
+
 log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -326,6 +328,15 @@ def scrape_playwright_company(target: dict) -> list[dict]:
                 job_url = href or target["url"]
                 ext_id = _make_external_id(target["name"], title, job_url)
 
+                # Try to lift a posted date from the card's visible text.
+                # Custom portals rarely surface a structured field, but many
+                # render "N days ago" or "2026-04-12" next to the title.
+                try:
+                    card_text = container.inner_text() or ""
+                except Exception:
+                    card_text = ""
+                posted_at = parse_posted_date(card_text)
+
                 jobs.append({
                     "external_id": ext_id,
                     "title": title,
@@ -337,7 +348,7 @@ def scrape_playwright_company(target: dict) -> list[dict]:
                     "ats": target["ats"],
                     "tier": target["tier"],
                     "is_remote": 0,
-                    "posted_at": None,
+                    "posted_at": posted_at,
                     "salary_min": 0,
                     "salary_max": 0,
                 })

--- a/backend/scrapers/utils.py
+++ b/backend/scrapers/utils.py
@@ -5,8 +5,77 @@ Shared utilities for all ATS scrapers.
 import re
 import time
 import logging
+from datetime import datetime, timezone, timedelta
 
 log = logging.getLogger(__name__)
+
+# Date-extraction patterns. Ordered by specificity so an absolute date
+# in the same blob beats a relative offset (e.g. "Posted 2025-04-15 · 99 days ago").
+_DATE_ISO_RE = re.compile(r"(\d{4}-\d{2}-\d{2})")
+_DATE_US_RE = re.compile(r"(\d{1,2})/(\d{1,2})/(\d{4})")
+_DATE_DAYS_AGO_RE = re.compile(r"(\d+)\s+days?\s+ago", re.IGNORECASE)
+_DATE_HOURS_AGO_RE = re.compile(r"(\d+)\s+hours?\s+ago", re.IGNORECASE)
+_DATE_TODAY_RE = re.compile(r"\b(posted\s+today|just\s+posted|today)\b", re.IGNORECASE)
+
+
+def parse_posted_date(text: str) -> str | None:
+    """Extract a posted date from raw ATS/portal text → ISO-8601 UTC string.
+
+    Handles four formats commonly seen across ATS pages:
+        • ISO date     "2025-04-15"
+        • US date      "04/15/2025"   (MM/DD/YYYY — Workday convention)
+        • Relative     "5 days ago", "6 hours ago"
+        • Same-day     "Posted today", "Just posted"
+
+    Returns None when no signal is found (uniform across callers). Relative
+    offsets are anchored to `datetime.now(UTC)` at call time. Absolute dates
+    win over relative offsets when both appear in the same blob. Bounds-checked
+    on the relative offsets to prevent regex matches against unrelated numbers
+    (e.g. "10000 days ago" from a salary string) producing a 1970 date.
+    """
+    if not text:
+        return None
+
+    m = _DATE_ISO_RE.search(text)
+    if m:
+        try:
+            return datetime.strptime(m.group(1), "%Y-%m-%d").replace(
+                tzinfo=timezone.utc
+            ).isoformat()
+        except ValueError:
+            pass
+
+    m = _DATE_US_RE.search(text)
+    if m:
+        try:
+            return datetime.strptime(
+                f"{m.group(1)}/{m.group(2)}/{m.group(3)}", "%m/%d/%Y"
+            ).replace(tzinfo=timezone.utc).isoformat()
+        except ValueError:
+            pass
+
+    m = _DATE_DAYS_AGO_RE.search(text)
+    if m:
+        try:
+            days = int(m.group(1))
+            if 0 <= days <= 3650:
+                return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+        except ValueError:
+            pass
+
+    m = _DATE_HOURS_AGO_RE.search(text)
+    if m:
+        try:
+            hours = int(m.group(1))
+            if 0 <= hours <= 24 * 365:
+                return (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
+        except ValueError:
+            pass
+
+    if _DATE_TODAY_RE.search(text):
+        return datetime.now(timezone.utc).isoformat()
+
+    return None
 
 REMOTE_KEYWORDS = [
     "remote", "anywhere", "distributed", "work from home",

--- a/backend/scrapers/workday.py
+++ b/backend/scrapers/workday.py
@@ -17,7 +17,7 @@ import logging
 import re
 from datetime import datetime, timezone, timedelta
 
-from .utils import parse_salary
+from .utils import parse_salary, parse_posted_date
 
 log = logging.getLogger(__name__)
 
@@ -44,26 +44,12 @@ SEARCH_TERMS = [
 
 
 def _parse_posted_date(posted_str: str) -> str:
-    """Parse Workday posted date formats to ISO 8601."""
-    if not posted_str:
-        return ""
-    # Format: "01/15/2024"
-    if re.match(r"\d{2}/\d{2}/\d{4}", posted_str):
-        try:
-            return datetime.strptime(posted_str, "%m/%d/%Y").replace(
-                tzinfo=timezone.utc
-            ).isoformat()
-        except Exception:
-            pass
-    # Format: "Posted 2 Days Ago"
-    m = re.search(r"(\d+)\s+day", posted_str.lower())
-    if m:
-        days = int(m.group(1))
-        return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
-    # Format: "Posted Today"
-    if "today" in posted_str.lower():
-        return datetime.now(timezone.utc).isoformat()
-    return ""
+    """Workday-specific wrapper around the shared parse_posted_date helper.
+
+    Preserves the legacy contract of returning "" (not None) for unparseable
+    input so existing callers / upsert paths don't see a type change.
+    """
+    return parse_posted_date(posted_str) or ""
 
 
 def scrape(company: dict):

--- a/backend/storage/db.py
+++ b/backend/storage/db.py
@@ -122,6 +122,9 @@ def init_db(db_path: str = DB_PATH):
     for ddl in (
         "ALTER TABLE jobs ADD COLUMN content_hash TEXT",
         "ALTER TABLE applications ADD COLUMN content_hash TEXT",
+        # cycles_missing: counts consecutive scrape cycles where a job's external_id
+        # was NOT seen. Used to distinguish "scraper hiccup" from "really removed".
+        "ALTER TABLE jobs ADD COLUMN cycles_missing INTEGER DEFAULT 0",
     ):
         try:
             conn.execute(ddl)
@@ -179,7 +182,8 @@ def upsert_job(conn: sqlite3.Connection, job: dict) -> str:
         ))
         return "new"
     else:
-        # Update last_seen and any changed fields
+        # Update last_seen and any changed fields. Reset cycles_missing on every
+        # sighting — a job that reappears after vanishing is treated as live again.
         conn.execute("""
             UPDATE jobs SET
                 title = ?, location = ?, department = ?,
@@ -187,7 +191,7 @@ def upsert_job(conn: sqlite3.Connection, job: dict) -> str:
                 salary_min = ?, salary_max = ?,
                 relevance_score = ?, matched_skills = ?,
                 sponsorship = ?, last_seen_at = ?, is_active = 1,
-                tier = ?, content_hash = ?
+                tier = ?, content_hash = ?, cycles_missing = 0
             WHERE external_id = ?
         """, (
             job["title"], job.get("location", ""), job.get("department", ""),
@@ -203,7 +207,10 @@ def upsert_job(conn: sqlite3.Connection, job: dict) -> str:
 
 
 def mark_stale_jobs(conn: sqlite3.Connection, hours: int = 72):
-    """Mark jobs not seen in the last N hours as inactive (likely taken down)."""
+    """Mark jobs not seen in the last N hours as inactive (likely taken down).
+
+    This is the time-based fallback; for cycle-driven scrapes prefer
+    increment_cycles_missing() which understands "missed N scrapes in a row"."""
     from datetime import timedelta
     cutoff = (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
     result = conn.execute(
@@ -212,6 +219,105 @@ def mark_stale_jobs(conn: sqlite3.Connection, hours: int = 72):
     )
     if result.rowcount > 0:
         log.info("Marked %d stale jobs as inactive", result.rowcount)
+
+
+def increment_cycles_missing(
+    conn: sqlite3.Connection,
+    seen_external_ids: set,
+    scraped_companies: set | None = None,
+    threshold: int = 3,
+) -> dict:
+    """Cycle-absence inference for active jobs.
+
+    For every is_active=1 job whose external_id is NOT in `seen_external_ids`,
+    bump `cycles_missing` by 1. Jobs that reach `threshold` consecutive misses
+    are flipped to is_active=0 (assumed taken down). A job that reappears in a
+    later cycle has its counter reset by upsert_job() — including jobs already
+    deactivated, which re-activate cleanly on the next sighting.
+
+    Args:
+        conn: open DB connection (caller owns commit).
+        seen_external_ids: external_ids observed in the just-finished cycle.
+        scraped_companies: company names whose scrapers actually ran this cycle.
+            Jobs from OTHER companies are left alone (they're on a rotating
+            schedule — see config.companies.get_batch). When None, all active
+            jobs are eligible for the penalty (callers must guarantee a full
+            sweep ran; partial sweeps will incorrectly penalise out-of-batch
+            jobs).
+        threshold: consecutive misses before deactivation. Default 3 — at one
+            full sweep per hour that's ≥2h of disappearance, which absorbs
+            transient ATS errors while still retiring genuinely removed posts.
+
+    Returns:
+        {"incremented": N, "deactivated": M} for logging.
+    """
+    if not isinstance(seen_external_ids, (set, frozenset)):
+        seen_external_ids = set(seen_external_ids or [])
+    if scraped_companies is not None and not isinstance(
+        scraped_companies, (set, frozenset)
+    ):
+        scraped_companies = set(scraped_companies or [])
+
+    # Run the increment + deactivate as one transaction. SQLite is single-writer
+    # under WAL — if a second writer (manual /api/scrape, parallel Actions run)
+    # is mid-write, `BEGIN IMMEDIATE` fails fast with SQLITE_BUSY instead of
+    # letting the two passes interleave and leave counters partially advanced.
+    # The `with conn:` block commits on clean exit and rolls back on exception,
+    # so a crash between the two UPDATEs cannot leave the table half-updated.
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+    except sqlite3.OperationalError as e:
+        log.warning("Cycle absence skipped — DB busy: %s", e)
+        return {"incremented": 0, "deactivated": 0}
+
+    try:
+        # Pull active jobs along with company so we can scope penalties to the
+        # companies that actually ran this cycle. Avoid a single giant NOT IN
+        # (...) against external_ids (SQLite var limit ~999) by diffing in
+        # Python.
+        active_rows = conn.execute(
+            "SELECT external_id, company FROM jobs WHERE is_active = 1"
+        ).fetchall()
+
+        if scraped_companies is not None:
+            candidate_rows = [r for r in active_rows if r[1] in scraped_companies]
+        else:
+            candidate_rows = active_rows
+
+        missing_ids = [r[0] for r in candidate_rows if r[0] not in seen_external_ids]
+        if not missing_ids:
+            conn.commit()
+            return {"incremented": 0, "deactivated": 0}
+
+        incremented = 0
+        CHUNK = 500
+        for i in range(0, len(missing_ids), CHUNK):
+            batch = missing_ids[i:i + CHUNK]
+            placeholders = ",".join("?" * len(batch))
+            cur = conn.execute(
+                f"UPDATE jobs SET cycles_missing = COALESCE(cycles_missing, 0) + 1 "
+                f"WHERE external_id IN ({placeholders}) AND is_active = 1",
+                batch,
+            )
+            incremented += cur.rowcount
+
+        cur = conn.execute(
+            "UPDATE jobs SET is_active = 0 "
+            "WHERE is_active = 1 AND COALESCE(cycles_missing, 0) >= ?",
+            (threshold,)
+        )
+        deactivated = cur.rowcount
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+    if incremented or deactivated:
+        log.info(
+            "Cycle absence: %d jobs incremented, %d deactivated (threshold=%d)",
+            incremented, deactivated, threshold,
+        )
+    return {"incremented": incremented, "deactivated": deactivated}
 
 
 def start_run(conn: sqlite3.Connection) -> int:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -597,13 +597,33 @@ export default function App() {
   const stats   = data?.stats  || {};
   const dist    = data?.distributions || {};
 
-  // Enrich jobs with derived fields
-  const enriched = useMemo(() => allJobs.map(j => ({
-    ...j,
-    _loc: normLoc(j.location, j.is_remote),
-    _cat: catOf(j.title),
-    _exp: expOf(j.title),
-  })), [allJobs]);
+  // Enrich jobs with derived fields. `_age_days` is computed from
+  // effective_date (posted_at || first_seen_at, from the backend) and used by
+  // the date filter AND the display-time relevance decay. Null when neither
+  // field is set — those jobs are treated as age-unknown and slip through the
+  // 30-day cap so we don't accidentally hide fresh ATS posts that lack dates.
+  const enriched = useMemo(() => allJobs.map(j => {
+    const eff = j.effective_date || j.posted_at || j.first_seen_at || "";
+    let ageDays = null;
+    if (eff) {
+      const t = new Date(eff).getTime();
+      if (!Number.isNaN(t)) {
+        ageDays = Math.max(0, (Date.now() - t) / 864e5);
+      }
+    }
+    // Display-only relevance: linear decay past day 14, floor at 0.5×.
+    // Original relevance_score is preserved for tracker/applications usage.
+    const base = j.relevance_score || 0;
+    const decay = ageDays == null ? 1 : Math.max(0.5, 1 - Math.max(0, ageDays - 14) / 60);
+    return {
+      ...j,
+      _loc: normLoc(j.location, j.is_remote),
+      _cat: catOf(j.title),
+      _exp: expOf(j.title),
+      _age_days: ageDays,
+      _display_score: base * decay,
+    };
+  }), [allJobs]);
 
   // Build company → applications map for "already applied here" intelligence
   const companyApps = useMemo(() => {
@@ -654,8 +674,15 @@ export default function App() {
     }
     if (selPosted!=="All") {
       const d={"24h":1,"3d":3,"7d":7,"14d":14,"30d":30}[selPosted]||9999;
-      j = j.filter(x=>x.posted_at&&(Date.now()-new Date(x.posted_at).getTime())<d*864e5);
+      // Age uses effective_date (posted_at || first_seen_at). Jobs with no
+      // date signal at all (_age_days === null) are excluded from explicit
+      // recency filters — we can't honestly claim they're under 7 days old.
+      j = j.filter(x => x._age_days != null && x._age_days < d);
     }
+    // Hard recency cap: hide jobs older than 30 days unless they're platinum
+    // tier (dream companies — keep them visible even if stale). Jobs with no
+    // effective_date pass through (we don't know they're old).
+    j = j.filter(x => x._age_days == null || x._age_days <= 30 || isPlatinum(x));
 
     if (q.trim()) {
       const ql = q.trim().toLowerCase();
@@ -676,7 +703,7 @@ export default function App() {
         if (bTarget !== aTarget) return bTarget - aTarget;
         const aSr = isSeniorFn(a.title)?1:0, bSr = isSeniorFn(b.title)?1:0;
         if (bSr !== aSr) return bSr - aSr;
-        return (b.relevance_score||0)-(a.relevance_score||0);
+        return (b._display_score||0)-(a._display_score||0);
       });
     } else {
       // Default browse: salary/date as selected, or relevance with dream-company boost
@@ -685,13 +712,14 @@ export default function App() {
         if (isPlatinum(a) && !isPlatinum(b)) return -1;
         if (!isPlatinum(a) && isPlatinum(b)) return 1;
         if (so==="salary") return (b.salary_max||0)-(a.salary_max||0);
-        if (so==="date")   return new Date(b.posted_at||0)-new Date(a.posted_at||0);
+        if (so==="date")   return new Date(b.effective_date||b.posted_at||0)-new Date(a.effective_date||a.posted_at||0);
         // Relevance sort: dream company gets +0.06 invisible boost so they surface first
-        // among jobs with nearly identical scores
-        const aScore = (a.relevance_score||0) + (isDreamCo(a.company)?0.06:0)
+        // among jobs with nearly identical scores. Uses the decayed display score
+        // so stale jobs sink even when nominally scored identically to fresh ones.
+        const aScore = (a._display_score||0) + (isDreamCo(a.company)?0.06:0)
                                                + (isTargetRoleFn(a.title)?0.03:0)
                                                + (isSeniorFn(a.title)?0.01:0);
-        const bScore = (b.relevance_score||0) + (isDreamCo(b.company)?0.06:0)
+        const bScore = (b._display_score||0) + (isDreamCo(b.company)?0.06:0)
                                                + (isTargetRoleFn(b.title)?0.03:0)
                                                + (isSeniorFn(b.title)?0.01:0);
         // Within a 0.05-wide score band, applied jobs drop to the bottom so


### PR DESCRIPTION
Closes #6.

## What changed

Three coordinated layers so the dashboard stops showing "18d ago" on every card:

1. **Playwright now extracts dates** — each card's visible text is scanned with a shared regex helper (`scrapers/utils.parse_posted_date`) for "N days ago", absolute ISO/US dates, and "today" / "just posted". Falls through to `None` when no signal exists.
2. **Cycle-absence inference** — new `jobs.cycles_missing` column. `increment_cycles_missing()` bumps the counter every cycle for active jobs whose `external_id` wasn't seen, deactivates at threshold 3, and resets via `upsert_job()` when a job reappears (so transient ATS errors don't permanently retire live posts). Scoped by `scraped_companies` so tier 2/3 jobs aren't penalised on cycles where their tier isn't on the rotation.
3. **`effective_date` in the export** — `posted_at || first_seen_at`, with naive ISO strings pinned to UTC so the frontend's `new Date(...)` doesn't reinterpret them as local time.
4. **Frontend recency filter** — uses `effective_date`; hides jobs older than 30 days unless `tier === 'platinum'`; applies linear decay to display/sort relevance past day 14 (`score *= max(0.5, 1 - max(0, age_days - 14) / 60)`). Underlying `relevance_score` is preserved — tracker and applications are unaffected.

## Self-critique (3 parallel reviews, all fixed before commit)

**A — Sanity (HIGH, fixed):** `greenhouse.py` / `ashby.py` / `bamboohr.py` slice `posted_at` to 19 chars (no offset). `first_seen_at` carries `+00:00`. `new Date()` in JS parses naive strings as local time → ages shifted by hours per user TZ. **Fix:** `_normalize_to_utc()` in `export_data.py` appends `+00:00` to bare 19-char ISO strings before they ship.

**B — Production (HIGH + HIGH, fixed):** (1) duplicate of A. (2) `increment_cycles_missing` had no atomic transaction — a crash between the increment pass and the deactivate pass could leave counters partially advanced, and concurrent writers (Render thread + Actions cron + manual `/api/scrape`) could interleave. **Fix:** wrapped in `BEGIN IMMEDIATE` + try/commit/rollback; `SQLITE_BUSY` returns no-op instead of partial state.

**C — Architecture (fixed):** `_extract_posted_at` in `playwright_scraper.py` duplicated `_parse_posted_date` in `workday.py` — same three formats, divergent return types (`None` vs `""`) and bounds. **Fix:** unified into `scrapers/utils.parse_posted_date`; both scrapers call it. Workday keeps a thin wrapper that returns `""` for back-compat.

## Deferred (justified)

**MEDIUM (B):** The static `frontend/public/api-data.json` doesn't carry `effective_date` until the next Actions run regenerates it (~hourly at :20). The frontend's defensive fallback chain (`j.effective_date || j.posted_at || j.first_seen_at`) keeps the dashboard functional during the propagation window — no crash, no blank pages. The task instructions explicitly list `frontend/public/api-data.json` as a do-not-modify file.

## Verification

- `python -m py_compile` clean on every backend file touched.
- Unit-level smoke tests with a tmp DB: 3-job export → all have `effective_date`; 4-job cycle test verifies increment, threshold-3 deactivation, reappearance reset, and out-of-batch company scoping.
- Timezone normalization tested with naive + offset-aware + missing `posted_at`.
- `parse_posted_date` validated across ISO, MM/DD/YYYY, days-ago, hours-ago, today, empty, None, and absolute-wins-over-relative cases.
- `vite build` clean (618 KB bundle, no new warnings).

## Files

- `backend/scrapers/utils.py` — new `parse_posted_date()`
- `backend/scrapers/playwright_scraper.py` — date extraction per card
- `backend/scrapers/workday.py` — refactor to share the helper
- `backend/storage/db.py` — `cycles_missing` column + `increment_cycles_missing()` + reset on upsert
- `backend/main.py` — track `seen_external_ids` + `scraped_companies`; call after both scraper paths
- `backend/export_data.py` — emit `effective_date`, pin naive ISO to UTC
- `frontend/src/App.jsx` — `_age_days`, `_display_score`, 30-day cap (platinum-exempt), decay-aware sort

---
_Generated by [Claude Code](https://claude.ai/code/session_016WFNi2CJcwwvj663QiJNi7)_