### PR TITLE
#19: Scrape status broker + live progress polling (tracer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to JobScout will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+- Thread-safe scrape status broker (`core/scrape_status.py`) and `GET /api/scrape/status` endpoint for live progress polling (#19).
+- Dashboard Monitor tab now shows live per-company scrape progress (current company, completed/total, jobs found, ETA) while a scrape is running (#19).
+
+### Fixed
+- `run_scrape()` TypeError on `POST /api/scrape` — caller signature aligned (#19).

--- a/backend/core/scrape_status.py
+++ b/backend/core/scrape_status.py
@@ -1,0 +1,130 @@
+"""
+Thread-safe scrape progress broker.
+
+Module-level singleton `broker` shared by the manual-trigger handler and
+the (future) background scrape thread. Tracks per-cycle progress so the
+dashboard can poll GET /api/scrape/status for live company-by-company
+status without coupling to the scraper internals.
+
+Watchdog: is_running() auto-flips to False if started_at is older than
+WATCHDOG_SECONDS (10 min) even when the internal flag is still set —
+this protects against a scraper thread that crashes before calling
+finish() and would otherwise wedge /api/scrape behind a 409 forever.
+"""
+
+import copy
+import threading
+from datetime import datetime, timezone
+
+WATCHDOG_SECONDS = 600  # 10 minutes
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class StatusBroker:
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._state: dict = {
+            "is_running":       False,
+            "started_at":       None,
+            "finished_at":      None,
+            "mode":             None,
+            "companies_done":   0,
+            "companies_total":  0,
+            "current_company":  None,
+            "found":            0,
+            "new":              0,
+            "errors":           0,
+            "eta_seconds":      None,
+            "final_stats":      None,
+        }
+
+    def start(self, mode: str, total: int) -> None:
+        with self._lock:
+            self._state.update({
+                "is_running":      True,
+                "started_at":      _now_iso(),
+                "finished_at":     None,
+                "mode":            mode,
+                "companies_done":  0,
+                "companies_total": max(int(total), 0),
+                "current_company": None,
+                "found":           0,
+                "new":             0,
+                "errors":          0,
+                "eta_seconds":     None,
+                "final_stats":     None,
+            })
+
+    def try_start(self, mode: str, total: int) -> bool:
+        """Atomic check-and-start: returns True if we successfully transitioned
+        from idle → running, False if a scrape was already running. The caller
+        uses this to gate the POST /api/scrape handler so rapid concurrent POSTs
+        can't both pass the is_running() check before either calls start()."""
+        with self._lock:
+            if self.is_running():
+                return False
+            self.start(mode, total)
+            return True
+
+    def tick(self, company: str, found_delta: int = 0, new_delta: int = 0,
+             error_delta: int = 0) -> None:
+        with self._lock:
+            self._state["current_company"] = company
+            self._state["companies_done"] += 1
+            self._state["found"]          += int(found_delta)
+            self._state["new"]            += int(new_delta)
+            self._state["errors"]         += int(error_delta)
+
+            done  = self._state["companies_done"]
+            total = self._state["companies_total"]
+            started = self._state["started_at"]
+            if done > 0 and total > done and started:
+                try:
+                    elapsed = (datetime.now(timezone.utc)
+                               - datetime.fromisoformat(started)).total_seconds()
+                    per_company = elapsed / done
+                    self._state["eta_seconds"] = round(per_company * (total - done), 1)
+                except Exception:
+                    self._state["eta_seconds"] = None
+            else:
+                self._state["eta_seconds"] = 0 if total and done >= total else None
+
+    def finish(self, stats: dict | None = None) -> None:
+        with self._lock:
+            self._state["is_running"]  = False
+            self._state["finished_at"] = _now_iso()
+            self._state["eta_seconds"] = 0
+            if stats:
+                self._state["final_stats"] = dict(stats)
+
+    def is_running(self) -> bool:
+        with self._lock:
+            if not self._state["is_running"]:
+                return False
+            started = self._state["started_at"]
+            if not started:
+                return False
+            try:
+                age = (datetime.now(timezone.utc)
+                       - datetime.fromisoformat(started)).total_seconds()
+            except Exception:
+                return False
+            if age > WATCHDOG_SECONDS:
+                # Stale run — auto-reset so a crashed scrape thread doesn't
+                # wedge the /api/scrape endpoint behind a permanent 409.
+                self._state["is_running"]  = False
+                self._state["finished_at"] = _now_iso()
+                return False
+            return True
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            snap = copy.deepcopy(self._state)
+            snap["is_running"] = self.is_running()
+            return snap
+
+
+broker = StatusBroker()

--- a/backend/server.py
+++ b/backend/server.py
@@ -24,6 +24,7 @@ import sys
 import json
 import time
 import logging
+import threading
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -35,6 +36,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from config.companies import COMPANIES, get_batch, TOTAL_COMPANIES
 from config.profile import PROFILE
 from core.relevance import RelevanceEngine
+from core.scrape_status import broker
 from storage.db import (
     init_db, get_conn, upsert_job, mark_stale_jobs,
     start_run, finish_run, get_stats,
@@ -201,60 +203,82 @@ def run_scrape(mode: str = "fast") -> dict:
         "updated": 0,  "errors": 0, "skipped": 0, "relevant": 0,
     }
 
-    for company in companies:
-        scraper = SCRAPERS.get(company.get("ats", ""))
-        if not scraper:
-            stats["errors"] += 1
-            continue
+    # If the caller (POST /api/scrape) has already armed the broker via
+    # try_start(), skip the re-start so we don't reset started_at and clobber
+    # the snapshot the response already returned. Direct callers (main.py CLI,
+    # any future background cron) hit the True branch.
+    if not broker.is_running():
+        broker.start(mode, len(companies))
+    try:
+        for company in companies:
+            scraper = SCRAPERS.get(company.get("ats", ""))
+            if not scraper:
+                stats["errors"] += 1
+                broker.tick(company.get("name", "?"), error_delta=1)
+                continue
 
-        try:
-            stats["companies"] += 1
-            for raw_job in scraper.scrape(company):
-                stats["found"] += 1
+            company_found = 0
+            company_new = 0
+            try:
+                stats["companies"] += 1
+                for raw_job in scraper.scrape(company):
+                    stats["found"] += 1
+                    company_found += 1
 
-                if not engine.is_relevant_title(raw_job.get("title", "")):
-                    stats["skipped"] += 1
-                    continue
+                    if not engine.is_relevant_title(raw_job.get("title", "")):
+                        stats["skipped"] += 1
+                        continue
 
-                score, matched = engine.score(raw_job)
-                raw_job["relevance_score"] = score
-                raw_job["matched_skills"]  = matched
-                raw_job["sponsorship"]     = _detect_sponsorship(raw_job)
+                    score, matched = engine.score(raw_job)
+                    raw_job["relevance_score"] = score
+                    raw_job["matched_skills"]  = matched
+                    raw_job["sponsorship"]     = _detect_sponsorship(raw_job)
 
-                # Skip jobs below the minimum score threshold — keeps DB clean
-                # and prevents low-signal roles from appearing in the dashboard.
-                # Threshold set in profile.py → min_score_threshold (default 0.30)
-                min_score = PROFILE.get("min_score_threshold", 0.30)
-                if score < min_score:
-                    stats["skipped"] += 1
-                    continue
+                    # Skip jobs below the minimum score threshold — keeps DB clean
+                    # and prevents low-signal roles from appearing in the dashboard.
+                    # Threshold set in profile.py → min_score_threshold (default 0.30)
+                    min_score = PROFILE.get("min_score_threshold", 0.30)
+                    if score < min_score:
+                        stats["skipped"] += 1
+                        continue
 
-                result = upsert_job(conn, raw_job)
-                if result == "new":
-                    stats["new"] += 1
-                    # Fire dream-job alert for new matches
-                    _maybe_alert(raw_job)
-                elif result == "updated":
-                    stats["updated"] += 1
-                stats["relevant"] += 1
+                    result = upsert_job(conn, raw_job)
+                    if result == "new":
+                        stats["new"] += 1
+                        company_new += 1
+                        # Fire dream-job alert for new matches
+                        _maybe_alert(raw_job)
+                    elif result == "updated":
+                        stats["updated"] += 1
+                    stats["relevant"] += 1
 
-            conn.commit()
-            time.sleep(SCRAPE_DELAY)
-        except Exception as e:
-            log.error("✗ %s — %s", company["name"], e)
-            stats["errors"] += 1
+                conn.commit()
+                broker.tick(company["name"], found_delta=company_found, new_delta=company_new)
+                time.sleep(SCRAPE_DELAY)
+            except Exception as e:
+                log.error("✗ %s — %s", company["name"], e)
+                stats["errors"] += 1
+                broker.tick(company.get("name", "?"),
+                            found_delta=company_found,
+                            new_delta=company_new,
+                            error_delta=1)
 
-    mark_stale_jobs(conn, hours=96)
-    conn.commit()
-    finish_run(conn, run_id, stats)
-    conn.close()
+        mark_stale_jobs(conn, hours=96)
+        conn.commit()
+        finish_run(conn, run_id, stats)
+        conn.close()
 
-    log.info(
-        "═══ %s cycle %d — companies=%d found=%d relevant=%d new=%d errors=%d ═══",
-        mode.upper(), cycle, stats["companies"], stats["found"],
-        stats["relevant"], stats["new"], stats["errors"],
-    )
-    return stats
+        log.info(
+            "═══ %s cycle %d — companies=%d found=%d relevant=%d new=%d errors=%d ═══",
+            mode.upper(), cycle, stats["companies"], stats["found"],
+            stats["relevant"], stats["new"], stats["errors"],
+        )
+        return stats
+    finally:
+        # Always flip the broker out of is_running, even if the loop bails on
+        # an unhandled exception — otherwise the 10-min watchdog would have to
+        # eventually rescue it.
+        broker.finish(stats)
 
 
 def _maybe_alert(job: dict):
@@ -313,30 +337,94 @@ def api_stats():
         return jsonify({"error": str(e)}), 500
 
 
-@app.route("/api/scrape", methods=["POST", "OPTIONS"])
-def api_trigger_scrape():
-    """Trigger an immediate full scrape (synchronous — GitHub Actions is the scheduler)."""
-    if request.method == "OPTIONS":
-        return "", 204
+def _count_fast_companies() -> int:
+    """Number of companies in 'fast' mode — Tier 0/1. Computed here so we can
+    pre-arm the broker with the real total inside the request handler, before
+    the worker thread starts. Keeps the snapshot returned by POST /api/scrape
+    immediately useful for the dashboard."""
+    return sum(1 for c in COMPANIES if c.get("tier", 3) in (0, 1))
 
-    if API_SECRET:
-        token = request.headers.get("Authorization", "").replace("Bearer ", "")
-        if token != API_SECRET:
-            return jsonify({"error": "unauthorized"}), 401
 
-    if state.is_scraping:
-        return jsonify({"status": "already_scraping", "message": "Scrape already running"}), 409
+def _run_scrape_async(mode: str = "fast") -> None:
+    """Background runner: executes a scrape, records cycle stats, rebuilds cache.
 
+    broker.finish() is guaranteed by run_scrape()'s own try/finally. We mirror
+    that pattern here so state.is_scraping is always cleared even on
+    unhandled-exception paths.
+    """
     state.is_scraping = True
     t0 = time.time()
     try:
-        stats = run_scrape("fast", delay=0.3)
+        stats = run_scrape(mode)
         state.record_cycle(time.time() - t0, stats)
         build_cache()
-        return jsonify({"ok": True, "stats": stats}), 200
     except Exception as e:
+        log.exception("Async scrape failed")
         state.record_cycle(0, {}, str(e))
-        return jsonify({"error": str(e)}), 500
+    finally:
+        # record_cycle() already clears is_scraping; keep this for the
+        # exception-before-record_cycle window.
+        state.is_scraping = False
+
+
+def _check_api_secret() -> bool:
+    """Returns True if the request is authorized (or no secret is configured)."""
+    if not API_SECRET:
+        return True
+    token = request.headers.get("Authorization", "").replace("Bearer ", "")
+    return token == API_SECRET
+
+
+@app.route("/api/scrape", methods=["POST", "OPTIONS"])
+def api_trigger_scrape():
+    """Trigger an immediate scrape in a background daemon thread.
+
+    Returns 202 with a status snapshot so the dashboard can poll
+    /api/scrape/status for live progress. A 409 is returned if a scrape is
+    already in flight (per the broker's 10-min watchdog).
+    """
+    if request.method == "OPTIONS":
+        return "", 204
+
+    if not _check_api_secret():
+        return jsonify({"error": "unauthorized"}), 401
+
+    # Atomic check-and-arm: closes the race where two concurrent POSTs both
+    # pass is_running() and spawn two scrape threads. The broker is armed
+    # synchronously before we return 202, so the embedded snapshot already
+    # shows is_running=True — no false "scrape complete" on the first poll.
+    if not broker.try_start("fast", _count_fast_companies()):
+        return jsonify({
+            "started":  False,
+            "reason":   "scrape_in_progress",
+            "snapshot": broker.snapshot(),
+        }), 409
+
+    threading.Thread(
+        target=_run_scrape_async,
+        args=("fast",),
+        daemon=True,
+        name="scrape-worker",
+    ).start()
+
+    return jsonify({
+        "started":  True,
+        "snapshot": broker.snapshot(),
+    }), 202
+
+
+@app.route("/api/scrape/status", methods=["GET"])
+def api_scrape_status():
+    """Live progress snapshot for the in-flight scrape (or last finished run).
+
+    Auth-gated symmetrically with POST /api/scrape: if API_SECRET is set, a
+    matching Bearer token is required. This prevents the snapshot leaking
+    cadence/company-name info to anonymous pollers in deployments that have
+    locked down the trigger.
+    """
+    if not _check_api_secret():
+        return jsonify({"error": "unauthorized"}), 401
+    return jsonify(broker.snapshot()), 200, {"Access-Control-Allow-Origin": "*"}
 
 
 # ─── Profile & Resume endpoints ────────────────────────────────────

--- a/backend/tests/test_scrape_status.py
+++ b/backend/tests/test_scrape_status.py
@@ -1,0 +1,165 @@
+"""Tests for the thread-safe scrape progress broker (core/scrape_status.py)."""
+import os
+import sys
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from core.scrape_status import StatusBroker, WATCHDOG_SECONDS
+
+
+def test_lifecycle():
+    """start → 3 ticks → finish flips is_running correctly and records counters."""
+    b = StatusBroker()
+    assert b.is_running() is False
+
+    b.start("fast", total=3)
+    assert b.is_running() is True
+    snap = b.snapshot()
+    assert snap["mode"] == "fast"
+    assert snap["companies_total"] == 3
+    assert snap["companies_done"] == 0
+    assert snap["started_at"] is not None
+
+    b.tick("Anthropic", found_delta=10, new_delta=2)
+    b.tick("OpenAI",    found_delta=8,  new_delta=1)
+    b.tick("Stripe",    found_delta=12, new_delta=4)
+
+    snap = b.snapshot()
+    assert snap["companies_done"] == 3
+    assert snap["found"] == 30
+    assert snap["new"] == 7
+    assert snap["current_company"] == "Stripe"
+
+    b.finish({"companies": 3, "found": 30, "new": 7, "errors": 0})
+    snap = b.snapshot()
+    assert snap["is_running"] is False
+    assert snap["finished_at"] is not None
+    assert snap["final_stats"]["new"] == 7
+
+
+def test_concurrent_ticks():
+    """4 threads × 100 ticks each → broker counters must sum to 400 with no drops."""
+    b = StatusBroker()
+    b.start("fast", total=400)
+
+    def worker(tag: str):
+        for _ in range(100):
+            b.tick(tag, found_delta=1, new_delta=0)
+
+    threads = [threading.Thread(target=worker, args=(f"t{i}",)) for i in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    snap = b.snapshot()
+    assert snap["companies_done"] == 400
+    assert snap["found"] == 400
+
+
+def test_snapshot_during_write():
+    """Reading snapshot() while another thread is calling tick() must not raise
+    and must always return a self-consistent dict."""
+    b = StatusBroker()
+    b.start("fast", total=1000)
+
+    stop = threading.Event()
+    errors: list = []
+
+    def writer():
+        i = 0
+        while not stop.is_set():
+            b.tick(f"co-{i}", found_delta=1, new_delta=1)
+            i += 1
+
+    def reader():
+        try:
+            for _ in range(500):
+                snap = b.snapshot()
+                # companies_done can never exceed found in this test because
+                # every tick increments both by 1 in lock-step.
+                assert snap["companies_done"] <= snap["found"]
+                assert isinstance(snap, dict)
+                assert "is_running" in snap
+        except Exception as e:
+            errors.append(e)
+
+    w = threading.Thread(target=writer)
+    r = threading.Thread(target=reader)
+    w.start(); r.start()
+    r.join()
+    stop.set()
+    w.join()
+
+    assert not errors, f"snapshot read raised: {errors}"
+
+
+def test_finish_without_start():
+    """finish() called with no prior start() must not raise; state stays not-running."""
+    b = StatusBroker()
+    # Should be a no-op (other than recording finished_at + final_stats)
+    b.finish({"any": "stats"})
+    snap = b.snapshot()
+    assert snap["is_running"] is False
+    # final_stats persisted even without a start
+    assert snap["final_stats"] == {"any": "stats"}
+
+
+def test_try_start_rejects_concurrent_starts():
+    """try_start() must be atomic — only one of N concurrent callers wins."""
+    b = StatusBroker()
+    winners: list[bool] = []
+    lock = threading.Lock()
+
+    def attempt():
+        ok = b.try_start("fast", total=10)
+        with lock:
+            winners.append(ok)
+
+    threads = [threading.Thread(target=attempt) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Exactly one caller transitioned idle → running.
+    assert sum(1 for w in winners if w) == 1
+    assert b.is_running() is True
+
+
+def test_try_start_after_finish():
+    """try_start() must succeed again after a finish() — runs aren't one-shot."""
+    b = StatusBroker()
+    assert b.try_start("fast", 3) is True
+    b.tick("a"); b.tick("b"); b.tick("c")
+    b.finish({"new": 1})
+    assert b.is_running() is False
+    # Second run starts cleanly.
+    assert b.try_start("full", 5) is True
+    snap = b.snapshot()
+    assert snap["mode"] == "full"
+    assert snap["companies_total"] == 5
+    assert snap["companies_done"] == 0   # counters reset
+
+
+def test_watchdog_stale_reset():
+    """If started_at is older than WATCHDOG_SECONDS, is_running() returns False
+    even if the internal flag is still True (auto-reset)."""
+    b = StatusBroker()
+    b.start("fast", total=5)
+    assert b.is_running() is True
+
+    # Backdate started_at to just past the watchdog window.
+    stale = datetime.now(timezone.utc) - timedelta(seconds=WATCHDOG_SECONDS + 30)
+    with b._lock:
+        b._state["started_at"] = stale.isoformat()
+        # Keep the flag True to prove the watchdog overrides it.
+        assert b._state["is_running"] is True
+
+    assert b.is_running() is False
+    # The watchdog should also have flipped the underlying flag.
+    snap = b.snapshot()
+    assert snap["is_running"] is False

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -493,27 +493,68 @@ export default function App() {
   const [applications, setApplications] = useState([]);
   const [appLoading, setAppLoading] = useState(false);
 
-  // Manual scrape trigger
-  const [scraping,setScraping]   = useState(false);
-  const [scrapeMsg,setScrapeMsg] = useState(null);
+  // Manual scrape trigger + live progress polling (#19).
+  // `scraping` reflects "we should keep polling the status endpoint" — set
+  // when the POST returns 202 or 409, and cleared once snapshot.is_running
+  // flips false. `scrapeProgress` is the latest snapshot from /api/scrape/status.
+  const [scraping,setScraping]         = useState(false);
+  const [scrapeMsg,setScrapeMsg]       = useState(null);
+  const [scrapeProgress,setScrapeProgress] = useState(null);
+
+  useEffect(() => {
+    if (!scraping || !RENDER_API) return;
+    let cancelled = false;
+    const tick = async () => {
+      // Skip polling while the tab is in the background — saves ~40 req/min
+      // per backgrounded tab on a free-tier Render instance.
+      if (typeof document !== "undefined" && document.hidden) return;
+      try {
+        const r = await fetch(`${RENDER_API}/api/scrape/status`,
+                              { signal: AbortSignal.timeout(5000) });
+        if (!r.ok) return;
+        const snap = await r.json();
+        if (cancelled) return;
+        setScrapeProgress(snap);
+        if (snap && snap.is_running === false) {
+          setScraping(false);
+          const s = snap.final_stats || {};
+          const totals = `companies=${s.companies ?? snap.companies_done ?? "?"} · `
+                       + `found=${s.found ?? snap.found ?? 0} · `
+                       + `new=${s.new ?? snap.new ?? 0}`;
+          setScrapeMsg(`✅ Scrape complete — ${totals}`);
+        }
+      } catch (_e) { /* transient — keep polling */ }
+    };
+    tick();
+    const id = setInterval(tick, 1500);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [scraping]);
 
   const triggerScrape = async () => {
     if (!RENDER_API) {
       setScrapeMsg("⚠️ No Render API configured. Set VITE_RENDER_URL in your .env file.");
       return;
     }
-    setScraping(true); setScrapeMsg(null);
+    setScrapeMsg(null);
     try {
       const resp = await fetch(`${RENDER_API}/api/scrape`, {
         method:"POST", headers:{"Content-Type":"application/json"},
         signal: AbortSignal.timeout(12000),
       });
-      const d = await resp.json();
-      if (resp.ok) setScrapeMsg("✅ Scrape triggered! New jobs will appear in ~2 minutes.");
-      else if (resp.status === 409) setScrapeMsg("⏳ Already scraping — please wait.");
-      else setScrapeMsg(`❌ Error: ${d.error || resp.status}`);
-    } catch(e) { setScrapeMsg(`❌ Could not reach Render: ${e.message}`); }
-    finally { setScraping(false); }
+      // 202 (new run) and 409 (already running) both transition us into the
+      // polling state — the snapshot endpoint is the single source of truth.
+      if (resp.status === 202 || resp.status === 409) {
+        const d = await resp.json().catch(() => ({}));
+        if (d && d.snapshot) setScrapeProgress(d.snapshot);
+        setScraping(true);
+        if (resp.status === 202) setScrapeMsg("🚀 Scrape started — live progress below.");
+        return;
+      }
+      const d = await resp.json().catch(() => ({}));
+      setScrapeMsg(`❌ Error: ${d.error || resp.status}`);
+    } catch(e) {
+      setScrapeMsg(`❌ Could not reach Render: ${e.message}`);
+    }
   };
 
   const fetchApplications = useCallback(async () => {
@@ -1756,8 +1797,18 @@ export default function App() {
                       fontFamily:"inherit",transition:"all .15s"}}>
                     {scraping?"⏳ Scraping...":"▶ Run Scrape Now"}
                   </button>
+                  {scraping && scrapeProgress && scrapeProgress.is_running && (
+                    <div style={{marginTop:10,fontSize:13,color:t.txS,fontWeight:500,lineHeight:1.5}}>
+                      Scraping: <strong style={{color:t.tx}}>{scrapeProgress.current_company || "starting…"}</strong>
+                      {" • "}{scrapeProgress.companies_done}/{scrapeProgress.companies_total} companies
+                      {" • "}{scrapeProgress.found} jobs found
+                      {scrapeProgress.new>0 && <> · <span style={{color:t.ok}}>{scrapeProgress.new} new</span></>}
+                      {scrapeProgress.eta_seconds!=null && scrapeProgress.eta_seconds>0 &&
+                        <> · ETA {Math.round(scrapeProgress.eta_seconds)}s</>}
+                    </div>
+                  )}
                   {scrapeMsg && (
-                    <div style={{marginTop:10,fontSize:14,color:scrapeMsg.startsWith("✅")?t.ok:scrapeMsg.startsWith("⏳")?t.wm:t.er,fontWeight:600}}>
+                    <div style={{marginTop:10,fontSize:14,color:scrapeMsg.startsWith("✅")?t.ok:scrapeMsg.startsWith("⏳")||scrapeMsg.startsWith("🚀")?t.wm:t.er,fontWeight:600}}>
                       {scrapeMsg}
                     </div>
                   )}


### PR DESCRIPTION
## Summary

Wave 1 of the Manual Triggers Reliability Sprint (parent: #18).

- **Fixes** the production `TypeError: run_scrape() got an unexpected keyword argument 'delay'` on `POST /api/scrape` (was at `server.py:321` calling `run_scrape("fast", delay=0.3)` against a `(mode)` signature).
- **Adds** `backend/core/scrape_status.py` — thread-safe `StatusBroker` singleton with `start()` / `tick()` / `finish()` / `try_start()` / `is_running()` / `snapshot()`. RLock-guarded; 10-minute watchdog auto-resets stale runs if a scrape thread crashes before `finish()`.
- **Instruments** `run_scrape()` with broker calls inside `try`/`finally` so `broker.finish(stats)` is guaranteed even on unhandled exceptions. Skips the inner `start()` when the broker is already armed (so `main.py` CLI direct calls still work, but POST-flow doesn't double-init).
- **Rewrites** `POST /api/scrape` to spawn a daemon thread and return `202` immediately with a snapshot that already shows `is_running: true`. Returns `409` (same snapshot shape) on duplicate POSTs. The check-and-arm uses an atomic `try_start()` to close the rapid double-POST race.
- **Adds** `GET /api/scrape/status` returning the current broker snapshot. Auth-gated symmetrically with `POST /api/scrape` (mirrors `API_SECRET` Bearer check) — closes the snapshot info-leak the production critique called out.
- **Wires** the dashboard Monitor tab to poll the new endpoint every 1.5s with a `document.hidden` guard. Renders `"Scraping: {current_company} • N/M companies • X jobs found · ETA Ns"` inline, then a `final_stats` toast on completion. `useEffect` cleanup calls `clearInterval` on unmount.
- **Tests** (`backend/tests/test_scrape_status.py`, 7 cases, all green): lifecycle, 400-tick concurrency, snapshot-during-write, finish-without-start, watchdog stale reset, atomic `try_start` (20 concurrent attempts → exactly 1 winner), back-to-back `try_start` after `finish()`.

## Verification

| Step | Result |
|---|---|
| `python -m py_compile backend/server.py backend/core/scrape_status.py` | OK |
| `python -m pytest backend/tests/test_scrape_status.py -v` | 7/7 passed |
| `python -m pytest backend/tests/ --ignore=tests/test_playwright.py` | **57/57** passed |
| `python -c "from server import app; print([r for r in app.url_map.iter_rules() if 'scrape' in str(r)])"` | `['/api/scrape', '/api/scrape/status']` ✓ |
| `npm install && npm run build` (frontend) | clean (1 stock chunk-size warning) |
| `python main.py --fast` regression | completes; uses its own scrape loop, unaffected |

### Smoke test (local server)

```
$ curl -X POST http://localhost:10000/api/scrape          # 202
{"snapshot":{"companies_done":0,"companies_total":58,"current_company":null,
 "errors":0,"eta_seconds":null,"final_stats":null,"finished_at":null,
 "found":0,"is_running":true,"mode":"fast","new":0,
 "started_at":"2026-05-15T16:50:39+00:00"},"started":true}

$ curl http://localhost:10000/api/scrape/status           # immediately after POST
{"companies_done":0,"companies_total":58,"current_company":null,
 "is_running":true, ...}                                  # is_running already true ✓

$ curl -X POST http://localhost:10000/api/scrape          # 409 (no duplicate run spawned)
{"started":false,"reason":"scrape_in_progress","snapshot":{...}}

$ curl http://localhost:10000/api/scrape/status           # 4 s later
{"companies_done":27,"companies_total":58,"current_company":"Anduril",
 "errors":16,"eta_seconds":4.6,"is_running":true, ...}
```

## Self-critique findings + how each was addressed

Three parallel critique agents (sanity / production / architecture) ran against the diff before commit. Findings:

### Addressed in this PR

- **[Sanity / critical]** First poll returned `is_running:false` because the request handler returned 202 *before* the worker thread had called `broker.start()`, so the dashboard would flash "✅ Scrape complete" milliseconds after the click. **Fixed** by introducing `broker.try_start(mode, total)` — an atomic check-and-arm primitive — and calling it synchronously in the POST handler with a precomputed `_count_fast_companies()`. `run_scrape()` now skips its inner `start()` when the broker is already armed. Same fix closes the **double-POST race** (two concurrent POSTs racing between `is_running()` and `start()`).
- **[Production]** Snapshot endpoint had no auth even though POST gates on `API_SECRET`. **Fixed** by extracting `_check_api_secret()` and applying it to `GET /api/scrape/status` as well.
- **[Production]** Polling load: 1.5 s polling = 40 req/min/tab on Render free tier. **Mitigated** by skipping polls while `document.hidden`. The natural termination is `is_running:false` so no hard cap is needed for the foreground case.
- **[Production]** `state.is_scraping` not cleared if `_run_scrape_async` raises before `record_cycle`. **Fixed** with a `finally:` belt-and-suspenders even though `record_cycle` already clears it on both success and error paths.

### Deferred (justified)

- **[Architecture]** Reviewer suggested moving `scrape_status.py` from `core/` (which contains pure-logic modules) to `storage/` (singleton + state), and extracting routes into a `routes/scrape_routes.py` Blueprint. The issue spec explicitly mandates `backend/core/scrape_status.py` and an inline route registration in `server.py`. Both are reasonable follow-ups — filing as part of #21 (the full `run_scrape` consolidation Wave). Keeping the spec-mandated layout for this tracer.
- **[Architecture]** Naming mismatch between broker keys (`companies_done`, `companies_total`) and `run_scrape()` stats dict (`companies`, etc.). The issue spec dictates the broker key names verbatim; the frontend handles both shapes (`final_stats.companies ?? snap.companies_done`). Will reconcile in #20.
- **[Production]** SIGTERM during deploy can kill the daemon thread mid-run; the 10-min watchdog inside `broker.is_running()` rescues the API, but the `scrape_runs` table can be left with an orphan `status='running'` row. Out of scope for this tracer — file as a Wave 2 hygiene task.

## Test plan

- [x] `pytest backend/tests/test_scrape_status.py` — 7 broker tests green
- [x] `pytest backend/tests/ --ignore=tests/test_playwright.py` — 57 backend tests green (no regression)
- [x] `npm run build` — frontend compiles
- [x] Local smoke test: POST returns 202, immediate-GET sees `is_running:true`, concurrent POST returns 409, mid-run status shows live progress + ETA
- [x] `python main.py --fast` still completes (separate scrape loop, untouched)
- [ ] Production smoke: deploy to Render, click "Run Scrape Now" from the dashboard, confirm live progress + completion toast

Closes #19.

https://claude.ai/code/session_014ZN8HY9Hyr6GEwMjvouZvV

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZN8HY9Hyr6GEwMjvouZvV)_