### PR TITLE
#22: Doctor health-check + admin Blueprint scaffold (tracer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to JobScout are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
+the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Admin Blueprint scaffold (routes/admin_routes.py) + GET /api/admin/doctor health-check endpoint with 6 probes (#22).

--- a/backend/routes/admin_routes.py
+++ b/backend/routes/admin_routes.py
@@ -1,0 +1,190 @@
+"""
+Admin API — Flask Blueprint for operator/health endpoints.
+
+Plug into server.py with:
+    from routes.admin_routes import admin_bp
+    app.register_blueprint(admin_bp)
+
+Endpoints:
+    GET /api/admin/doctor   — Server health probe (DB, scrapers, env, vault, disk)
+"""
+
+import importlib
+import logging
+import os
+import shutil
+from datetime import datetime, timezone
+
+from flask import Blueprint, jsonify, request
+
+log = logging.getLogger(__name__)
+
+admin_bp = Blueprint("admin", __name__, url_prefix="/api/admin")
+
+DB_PATH = os.environ.get("DB_PATH", os.path.join(os.path.dirname(__file__), "..", "jobscout.db"))
+API_SECRET = os.environ.get("API_SECRET", "")
+
+VAULT_ROOT = os.path.join(os.path.dirname(__file__), "..", "resume_vault")
+SCRAPER_MODULES = ["greenhouse", "lever", "ashby", "smartrecruiters", "bamboohr", "workday"]
+
+
+def _check(name: str, status: str, detail: str) -> dict:
+    return {"name": name, "status": status, "detail": detail}
+
+
+def _check_db_connectivity() -> dict:
+    # Use storage.db.get_conn so we exercise the same WAL-mode connection
+    # the rest of the app actually uses, not a raw sqlite3.connect.
+    try:
+        from storage.db import get_conn
+        conn = get_conn(DB_PATH)
+        try:
+            conn.execute("SELECT 1").fetchone()
+        finally:
+            conn.close()
+        return _check("db_connectivity", "pass", "SELECT 1 OK")
+    except Exception as e:
+        return _check("db_connectivity", "fail", f"DB unreachable: {e.__class__.__name__}")
+
+
+def _check_scrapers_importable() -> dict:
+    missing = []
+    for mod in SCRAPER_MODULES:
+        try:
+            importlib.import_module(f"scrapers.{mod}")
+        except Exception as e:
+            missing.append(f"{mod} ({e.__class__.__name__})")
+    if missing:
+        return _check("scrapers_importable", "fail",
+                      f"missing: {', '.join(missing)}; ok: {len(SCRAPER_MODULES) - len(missing)}/{len(SCRAPER_MODULES)}")
+    return _check("scrapers_importable", "pass",
+                  f"all {len(SCRAPER_MODULES)} scrapers importable")
+
+
+def _check_recent_scrape_run() -> dict:
+    # finish_run() in storage/db.py writes status='complete'; tolerate
+    # legacy 'success' rows as well.
+    try:
+        from storage.db import get_conn
+        conn = get_conn(DB_PATH)
+        try:
+            row = conn.execute(
+                "SELECT MAX(finished_at) FROM scrape_runs WHERE status IN ('success','complete')"
+            ).fetchone()
+        finally:
+            conn.close()
+        last = row[0] if row else None
+        if not last:
+            # Fresh deploy with no scrape history is a soft signal, not a failure.
+            return _check("recent_scrape_run", "warn", "no completed scrape runs yet")
+        try:
+            finished = datetime.fromisoformat(last.replace("Z", "+00:00"))
+            if finished.tzinfo is None:
+                finished = finished.replace(tzinfo=timezone.utc)
+        except Exception:
+            return _check("recent_scrape_run", "warn", f"unparseable timestamp: {last}")
+        age_h = (datetime.now(timezone.utc) - finished).total_seconds() / 3600
+        if age_h < 24:
+            return _check("recent_scrape_run", "pass", f"last success {age_h:.1f}h ago")
+        if age_h < 72:
+            return _check("recent_scrape_run", "warn", f"last success {age_h:.1f}h ago (>24h)")
+        return _check("recent_scrape_run", "fail", f"last success {age_h:.1f}h ago (>72h)")
+    except Exception as e:
+        return _check("recent_scrape_run", "fail", f"query failed: {e.__class__.__name__}")
+
+
+def _check_env_vars_present() -> dict:
+    # DB_PATH has a code-level default → always considered set.
+    optional = ["DISCORD_WEBHOOK_URL", "TELEGRAM_BOT_TOKEN"]
+    missing_count = sum(1 for v in optional if not os.environ.get(v))
+    if missing_count:
+        return _check("env_vars_present", "warn",
+                      f"DB_PATH ok; {missing_count}/{len(optional)} optional alert vars unset")
+    return _check("env_vars_present", "pass",
+                  "DB_PATH ok; all optional alert vars set")
+
+
+def _check_vault_dirs_writable() -> dict:
+    # Vault subdirs are gitignored and created lazily on first upload, so
+    # "missing" is a soft signal (warn). Existing-but-unwritable is hard fail.
+    pdf_dir = os.path.join(VAULT_ROOT, "pdf")
+    text_dir = os.path.join(VAULT_ROOT, "text")
+    fails, warns = [], []
+    for label, path in [("pdf", pdf_dir), ("text", text_dir)]:
+        if not os.path.isdir(path):
+            warns.append(f"{label}/ not yet provisioned")
+        elif not os.access(path, os.W_OK):
+            fails.append(f"{label}/ not writable")
+    if fails:
+        return _check("vault_dirs_writable", "fail", "; ".join(fails + warns))
+    if warns:
+        return _check("vault_dirs_writable", "warn", "; ".join(warns))
+    return _check("vault_dirs_writable", "pass", "pdf/ and text/ writable")
+
+
+def _check_disk_space() -> dict:
+    try:
+        usage = shutil.disk_usage("/")
+        free_mb = usage.free / (1024 * 1024)
+    except Exception:
+        return _check("disk_space", "warn", "unavailable on this platform")
+    if free_mb < 100:
+        return _check("disk_space", "fail", f"{free_mb:.0f}MB free (<100MB)")
+    if free_mb < 500:
+        return _check("disk_space", "warn", f"{free_mb:.0f}MB free (<500MB)")
+    return _check("disk_space", "pass", f"{free_mb:.0f}MB free")
+
+
+def _aggregate(checks: list) -> str:
+    statuses = {c["status"] for c in checks}
+    if "fail" in statuses:
+        return "fail"
+    if "warn" in statuses:
+        return "warn"
+    return "pass"
+
+
+# Registry — tests can monkeypatch this list to inject fakes.
+DOCTOR_CHECKS = [
+    _check_db_connectivity,
+    _check_scrapers_importable,
+    _check_recent_scrape_run,
+    _check_env_vars_present,
+    _check_vault_dirs_writable,
+    _check_disk_space,
+]
+
+
+@admin_bp.route("/doctor", methods=["GET", "OPTIONS"])
+def doctor():
+    """Run all health probes; return per-check results + aggregated overall status."""
+    if request.method == "OPTIONS":
+        return "", 200
+
+    if API_SECRET:
+        token = request.headers.get("Authorization", "").replace("Bearer ", "")
+        if token != API_SECRET:
+            return jsonify({"error": "unauthorized"}), 401
+
+    checks = []
+    for fn in DOCTOR_CHECKS:
+        try:
+            checks.append(fn())
+        except Exception as e:
+            log.exception("doctor check %s crashed", getattr(fn, "__name__", fn))
+            checks.append(_check(getattr(fn, "__name__", "unknown"), "fail",
+                                 f"check crashed: {e}"))
+
+    return jsonify({
+        "checks": checks,
+        "overall": _aggregate(checks),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }), 200
+
+
+@admin_bp.after_request
+def admin_cors(response):
+    response.headers["Access-Control-Allow-Origin"] = "*"
+    response.headers["Access-Control-Allow-Methods"] = "GET, POST, DELETE, OPTIONS"
+    response.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
+    return response

--- a/backend/server.py
+++ b/backend/server.py
@@ -58,8 +58,10 @@ app = Flask(__name__)
 
 
 # ─── Scraper Registry ──────────────────────────────────────────────
-from routes.vault_routes import vault_bp 
+from routes.vault_routes import vault_bp
 app.register_blueprint(vault_bp)
+from routes.admin_routes import admin_bp
+app.register_blueprint(admin_bp)
 SCRAPERS: dict = {}
 
 def _load_scrapers():

--- a/backend/tests/test_admin_routes.py
+++ b/backend/tests/test_admin_routes.py
@@ -1,0 +1,105 @@
+"""Tests for /api/admin/doctor health-check endpoint."""
+import importlib
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "test.db")
+    from storage.db import init_db
+    init_db(db_path)
+
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.delenv("API_SECRET", raising=False)
+
+    # Force re-import so DB_PATH/API_SECRET pick up the patched env.
+    for mod in ["routes.admin_routes", "server"]:
+        if mod in sys.modules:
+            del sys.modules[mod]
+
+    import server
+    server.DB_PATH = db_path
+    server.app.config["TESTING"] = True
+    with server.app.test_client() as c:
+        yield c
+
+
+def test_doctor_returns_200(client):
+    resp = client.get("/api/admin/doctor")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data.get("checks"), list)
+    assert isinstance(data.get("overall"), str)
+    assert data["overall"] in {"pass", "warn", "fail"}
+
+
+def test_doctor_minimum_checks(client):
+    resp = client.get("/api/admin/doctor")
+    data = resp.get_json()
+    assert len(data["checks"]) >= 6
+    for c in data["checks"]:
+        assert set(c.keys()) >= {"name", "status", "detail"}
+        assert c["status"] in {"pass", "warn", "fail"}
+        assert isinstance(c["name"], str) and c["name"]
+        assert isinstance(c["detail"], str)
+
+
+def test_doctor_status_aggregation(client, monkeypatch):
+    import routes.admin_routes as ar
+
+    def all_pass():
+        return [
+            lambda: ar._check("a", "pass", "ok"),
+            lambda: ar._check("b", "pass", "ok"),
+        ]
+
+    def with_warn():
+        return [
+            lambda: ar._check("a", "pass", "ok"),
+            lambda: ar._check("b", "warn", "soft"),
+        ]
+
+    def with_fail():
+        return [
+            lambda: ar._check("a", "pass", "ok"),
+            lambda: ar._check("b", "warn", "soft"),
+            lambda: ar._check("c", "fail", "broken"),
+        ]
+
+    monkeypatch.setattr(ar, "DOCTOR_CHECKS", all_pass())
+    assert client.get("/api/admin/doctor").get_json()["overall"] == "pass"
+
+    monkeypatch.setattr(ar, "DOCTOR_CHECKS", with_warn())
+    assert client.get("/api/admin/doctor").get_json()["overall"] == "warn"
+
+    monkeypatch.setattr(ar, "DOCTOR_CHECKS", with_fail())
+    assert client.get("/api/admin/doctor").get_json()["overall"] == "fail"
+
+
+def test_doctor_auth_optional(client, monkeypatch):
+    monkeypatch.delenv("API_SECRET", raising=False)
+    import routes.admin_routes as ar
+    ar.API_SECRET = ""
+    resp = client.get("/api/admin/doctor")
+    assert resp.status_code == 200
+
+
+def test_doctor_check_crash_does_not_500(client, monkeypatch):
+    """A single misbehaving check should fail-closed inside its own entry, not crash the route."""
+    import routes.admin_routes as ar
+
+    def boom():
+        raise RuntimeError("simulated probe failure")
+
+    monkeypatch.setattr(ar, "DOCTOR_CHECKS", [boom, lambda: ar._check("ok", "pass", "fine")])
+    resp = client.get("/api/admin/doctor")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    statuses = [c["status"] for c in data["checks"]]
+    assert "fail" in statuses
+    assert data["overall"] == "fail"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -516,6 +516,34 @@ export default function App() {
     finally { setScraping(false); }
   };
 
+  // Doctor health-check
+  const [doctorLoading,setDoctorLoading] = useState(false);
+  const [doctorResult,setDoctorResult]   = useState(null);
+  const [doctorErr,setDoctorErr]         = useState(null);
+
+  const runDoctor = async () => {
+    if (!RENDER_API) {
+      setDoctorErr("No Render API configured. Set VITE_RENDER_URL in your .env file.");
+      return;
+    }
+    setDoctorLoading(true); setDoctorErr(null); setDoctorResult(null);
+    try {
+      const resp = await fetch(`${RENDER_API}/api/admin/doctor`, {
+        signal: AbortSignal.timeout(15000),
+      });
+      const d = await resp.json();
+      if (!resp.ok) {
+        setDoctorErr(d.error || `HTTP ${resp.status}`);
+      } else {
+        setDoctorResult(d);
+      }
+    } catch(e) {
+      setDoctorErr(`Could not reach Render: ${e.message}`);
+    } finally {
+      setDoctorLoading(false);
+    }
+  };
+
   const fetchApplications = useCallback(async () => {
     setAppLoading(true);
     try {
@@ -1761,6 +1789,56 @@ export default function App() {
                       {scrapeMsg}
                     </div>
                   )}
+                </div>
+
+                {/* Doctor health-check */}
+                <div style={{padding:18,borderRadius:12,background:t.bgS,border:`1px solid ${t.bd}`}}>
+                  <div style={{fontSize:15,fontWeight:700,color:t.tx,marginBottom:6}}>🩺 Doctor</div>
+                  <div style={{fontSize:13,color:t.txM,marginBottom:14}}>
+                    Run server health probes: DB connectivity, scraper imports, recent scrape success, env vars, vault dirs, disk space.
+                    {!RENDER_API && <span style={{color:t.er}}> (Set VITE_RENDER_URL to enable)</span>}
+                  </div>
+                  <button onClick={runDoctor} disabled={doctorLoading||!RENDER_API}
+                    style={{padding:"11px 22px",borderRadius:9,border:"none",
+                      background:doctorLoading?t.bgS:(RENDER_API?t.gP:`${t.txM}20`),
+                      color:doctorLoading||!RENDER_API?t.txM:"#fff",
+                      fontSize:14,fontWeight:700,cursor:doctorLoading||!RENDER_API?"not-allowed":"pointer",
+                      fontFamily:"inherit",transition:"all .15s"}}>
+                    {doctorLoading?"⏳ Running checks…":"▶ Run Doctor"}
+                  </button>
+                  {doctorErr && (
+                    <div style={{marginTop:10,fontSize:14,color:t.er,fontWeight:600}}>❌ {doctorErr}</div>
+                  )}
+                  {doctorResult && (() => {
+                    const overall = doctorResult.overall;
+                    const overallColor = overall==="pass"?"#4ADE80":overall==="warn"?"#F59E0B":"#EF4444";
+                    return (
+                      <div style={{marginTop:14}}>
+                        <div style={{display:"flex",alignItems:"center",gap:10,marginBottom:12,padding:"10px 14px",
+                          background:`${overallColor}15`,border:`1px solid ${overallColor}40`,borderRadius:8}}>
+                          <span style={{fontSize:13,color:t.txM,fontWeight:700,textTransform:"uppercase",letterSpacing:".06em"}}>Overall</span>
+                          <span style={{fontSize:15,fontWeight:800,color:overallColor,textTransform:"uppercase",letterSpacing:".05em"}}>{overall}</span>
+                        </div>
+                        <div style={{display:"flex",flexDirection:"column",gap:8}}>
+                          {(doctorResult.checks||[]).map((c,i) => {
+                            const color = c.status==="pass"?"#4ADE80":c.status==="warn"?"#F59E0B":"#EF4444";
+                            return (
+                              <div key={i} style={{padding:"10px 12px",borderRadius:8,
+                                background:t.cd,border:`1px solid ${t.bd}`}}>
+                                <div style={{display:"flex",alignItems:"center",gap:10,marginBottom:4}}>
+                                  <span style={{fontSize:11,fontWeight:800,color:"#fff",
+                                    background:color,padding:"2px 8px",borderRadius:4,
+                                    textTransform:"uppercase",letterSpacing:".05em"}}>{c.status}</span>
+                                  <span style={{fontSize:14,fontWeight:700,color:t.tx,fontFamily:"monospace"}}>{c.name}</span>
+                                </div>
+                                <div style={{fontSize:13,color:t.txM,marginLeft:2}}>{c.detail}</div>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    );
+                  })()}
                 </div>
 
                 {/* GitHub Actions button */}


### PR DESCRIPTION
Closes #22 · Wave 1 of the Manual Triggers Reliability Sprint (parent PRD #18). Runs in parallel with #19.

## Summary

Operators previously had to SSH into Render to verify whether scrapers were importable, the DB was reachable, or a successful scrape had run recently. This PR introduces:

1. **`backend/routes/admin_routes.py`** — a new Flask Blueprint (`/api/admin/...`) that mirrors the shape of `routes/vault_routes.py`. The lowest-risk endpoint, `GET /api/admin/doctor`, is the tracer for this pattern; destructive admin ops in #23/#24 will reuse it.
2. **Frontend Doctor card** in the Manual Triggers panel — one-click run, inline render of every probe with green / amber / red status badges and an aggregated `overall`.

The Blueprint pattern + dashboard admin-card UI are the reusable artifacts.

## Endpoint

`GET /api/admin/doctor` returns:

```json
{
  "checks": [{"name": "...", "status": "pass|warn|fail", "detail": "..."}, ...],
  "overall": "pass|warn|fail",
  "generated_at": "<iso8601>"
}
```

`overall` = `fail` if any check fails, else `warn` if any warns, else `pass`.

## Six probes

| Check | Pass | Warn | Fail |
|---|---|---|---|
| `db_connectivity` | `SELECT 1` succeeds via `storage.db.get_conn` (WAL parity) | — | exception |
| `scrapers_importable` | all 6 ATS modules import | — | any missing |
| `recent_scrape_run` | last `complete`/`success` < 24h | < 72h **or** none yet | > 72h |
| `env_vars_present` | DB_PATH ok + all optional alert vars set | optional alert vars unset | — |
| `vault_dirs_writable` | both pdf/ + text/ writable | dirs not yet provisioned (lazy) | exists but unwritable |
| `disk_space` | ≥ 500 MB free | < 500 MB **or** unavailable | < 100 MB |

Auth: optional `Bearer ${API_SECRET}` header, mirroring `/api/scrape`.

## Smoke test

```
$ curl http://localhost:10000/api/admin/doctor | jq
{
  "checks": [
    {"name": "db_connectivity",     "status": "pass", "detail": "SELECT 1 OK"},
    {"name": "scrapers_importable", "status": "pass", "detail": "all 6 scrapers importable"},
    {"name": "recent_scrape_run",   "status": "warn", "detail": "no completed scrape runs yet"},
    {"name": "env_vars_present",    "status": "warn", "detail": "DB_PATH ok; 2/2 optional alert vars unset"},
    {"name": "vault_dirs_writable", "status": "pass", "detail": "pdf/ and text/ writable"},
    {"name": "disk_space",          "status": "pass", "detail": "30502MB free"}
  ],
  "generated_at": "2026-05-15T16:50:38.939289+00:00",
  "overall": "warn"
}
```

## Tests (5 / 5 passing, 68 / 68 in full suite)

```
tests/test_admin_routes.py::test_doctor_returns_200             PASSED
tests/test_admin_routes.py::test_doctor_minimum_checks          PASSED
tests/test_admin_routes.py::test_doctor_status_aggregation      PASSED
tests/test_admin_routes.py::test_doctor_auth_optional           PASSED
tests/test_admin_routes.py::test_doctor_check_crash_does_not_500 PASSED
```

`DOCTOR_CHECKS` is a module-level list so tests can monkeypatch it to inject fakes for aggregation testing. A misbehaving probe is caught by the route handler so a single bad check can never 500 the endpoint.

## Self-critique findings (3 parallel review agents) and resolutions

**Agent A (Sanity)** — *`_check_vault_dirs_writable` falsely fails on every fresh deploy because the vault dirs are gitignored.*
→ **Fixed.** Missing dirs now return `warn` ("not yet provisioned"); only `exists-but-unwritable` returns `fail`.
→ **Also fixed:** `_check_recent_scrape_run` empty-table case downgraded from `fail` to `warn` for the same reason.

**Agent B (Production)** — three risks:
1. *`_check_env_vars_present` enumerates which alert env vars are missing by name (info disclosure).*
   → **Fixed.** Detail now reports `"2/2 optional alert vars unset"` instead of naming each. Names remain in the source registry, where they belong.
   → Also fixed the dead `db_path_set = ... or True` expression and the bare `except Exception as e: ... f"...{e}"` formatting that could leak SQL strings — exception type only is now surfaced.
2. *Could `/api/admin/doctor` collide with another `/api/<X>`?*
   → **Verified safe.** No catch-all routes in `server.py` or `vault_routes.py`. `url_prefix="/api/admin"` is unique.
3. *Synchronous `shutil.disk_usage` + un-indexed `scrape_runs` query could block worker threads under load.*
   → **Acknowledged, not fixed in this PR.** Table is small (~288 rows/day, never pruned today), DB has 2.0s connection timeout, and the endpoint is intentionally a synchronous probe so a slow underlying system is *itself* the signal a doctor should surface. Adding a `scrape_runs(finished_at)` index and async caching are reasonable follow-ups for #23/#24 once we observe real production latency.

**Agent C (Architecture)** — *admin_routes opens raw `sqlite3.connect()` connections instead of going through `storage.db.get_conn()`, which sets WAL mode and other pragmas.*
→ **Fixed.** Both DB-touching probes (`_check_db_connectivity`, `_check_recent_scrape_run`) now go through `storage.db.get_conn`, so the doctor exercises the same connection profile the rest of the app uses. Removed the now-unused `import sqlite3`.

## Files changed

- **+** `backend/routes/admin_routes.py` (175 LOC)
- **+** `backend/tests/test_admin_routes.py` (5 tests)
- **+** `CHANGELOG.md` (Unreleased / Added)
- **M** `backend/server.py` (Blueprint registration after `vault_bp`)
- **M** `frontend/src/App.jsx` (Doctor card in Manual Triggers panel)

## Test plan

- [x] `python -m py_compile backend/routes/admin_routes.py backend/server.py`
- [x] `pytest tests/test_admin_routes.py -v` — 5/5 pass
- [x] `pytest tests/` — 68/68 pass (no regressions)
- [x] Route registration verified — `/api/admin/doctor` present in `app.url_map`
- [x] Smoke test — `curl /api/admin/doctor` renders 6 checks with sensible aggregated `overall`
- [x] `npm run build` — frontend compiles, "Doctor" + "Running checks" strings present in the bundle
- [ ] Verify Doctor card visually on Render once deployed
- [ ] Confirm `overall` flips to `pass` after first successful scrape lands

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jfdq2vR65RGnNq6NjieBFL)_