### PR TITLE
#20: Concurrency guard + progress-bar UI + background thread broker integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Concurrency guard on POST /api/scrape (returns 409 when scrape active) + progress-bar UI + background scrape thread reports via shared broker (#20).
 - Admin Blueprint scaffold (routes/admin_routes.py) + GET /api/admin/doctor health-check endpoint with 6 probes (#22).
 - Thread-safe scrape status broker (`core/scrape_status.py`) and `GET /api/scrape/status` endpoint for live progress polling (#19).
 - Dashboard Monitor tab now shows live per-company scrape progress (current company, completed/total, jobs found, ETA) while a scrape is running (#19).

--- a/backend/core/scrape_status.py
+++ b/backend/core/scrape_status.py
@@ -29,6 +29,7 @@ class StatusBroker:
         self._state: dict = {
             "is_running":       False,
             "started_at":       None,
+            "last_tick_at":     None,
             "finished_at":      None,
             "mode":             None,
             "companies_done":   0,
@@ -43,9 +44,11 @@ class StatusBroker:
 
     def start(self, mode: str, total: int) -> None:
         with self._lock:
+            now = _now_iso()
             self._state.update({
                 "is_running":      True,
-                "started_at":      _now_iso(),
+                "started_at":      now,
+                "last_tick_at":    now,
                 "finished_at":     None,
                 "mode":            mode,
                 "companies_done":  0,
@@ -77,6 +80,10 @@ class StatusBroker:
             self._state["found"]          += int(found_delta)
             self._state["new"]            += int(new_delta)
             self._state["errors"]         += int(error_delta)
+            # Liveness signal for the watchdog — without this, a long but
+            # healthy scrape would be auto-killed at WATCHDOG_SECONDS even
+            # though it's still making progress.
+            self._state["last_tick_at"] = _now_iso()
 
             done  = self._state["companies_done"]
             total = self._state["companies_total"]
@@ -104,12 +111,16 @@ class StatusBroker:
         with self._lock:
             if not self._state["is_running"]:
                 return False
-            started = self._state["started_at"]
-            if not started:
+            # Watchdog uses last_tick_at (set by tick()) so a healthy
+            # long-running scrape can't be auto-killed — only one that has
+            # gone silent for WATCHDOG_SECONDS counts as wedged. Falls back
+            # to started_at for runs that haven't ticked yet.
+            last = self._state.get("last_tick_at") or self._state.get("started_at")
+            if not last:
                 return False
             try:
                 age = (datetime.now(timezone.utc)
-                       - datetime.fromisoformat(started)).total_seconds()
+                       - datetime.fromisoformat(last)).total_seconds()
             except Exception:
                 return False
             if age > WATCHDOG_SECONDS:

--- a/backend/server.py
+++ b/backend/server.py
@@ -881,10 +881,65 @@ def add_cors(response):
     return response
 
 
+# ─── Background scrape loop ───────────────────────────────────────
+# Wraps run_scrape() in a daemon thread so the dashboard sees the broker
+# tick in real time even when the cycle wasn't user-triggered. Skips when
+# the broker is already running (a manual POST /api/scrape can race the
+# cron tick — manual wins; this thread quietly waits for the next slot).
+def _bg_scrape_loop() -> None:
+    log.info("Background scraper enabled — interval=%ds", FAST_INTERVAL)
+    # First tick gets a short delay so the Flask boot path isn't competing
+    # with the scraper for SQLite init/imports on cold starts.
+    time.sleep(15)
+    while True:
+        try:
+            if is_quiet_hours():
+                log.debug("BG scrape: quiet hours, skipping")
+            elif not broker.try_start("fast", _count_fast_companies()):
+                # Atomic check-and-arm: must mirror POST /api/scrape's gate
+                # exactly. A plain `if broker.is_running()` check would leave
+                # a race window where a manual POST wins the broker while
+                # we're about to call run_scrape() — both threads would then
+                # tick the same broker and double-scrape the same companies.
+                log.debug("BG scrape: broker busy, skipping cycle")
+            else:
+                log.info("BG scrape: starting fast cycle")
+                threading.Thread(
+                    target=_run_scrape_async,
+                    args=("fast",),
+                    daemon=True,
+                    name="bg-scrape-worker",
+                ).start()
+        except Exception:
+            # Never let the loop die — log and continue. The 10-min watchdog
+            # in StatusBroker.is_running() rescues us if a scrape crashed
+            # before its finally-finish() ran.
+            log.exception("BG scrape loop tick failed")
+        time.sleep(FAST_INTERVAL)
+
+
+def _should_run_bg_scraper() -> bool:
+    """Background loop is opt-out via DISABLE_BG_SCRAPE=1, and auto-disabled
+    under pytest so test_client() reloads don't spawn rogue threads that
+    write to the test DB."""
+    if "PYTEST_CURRENT_TEST" in os.environ or "pytest" in sys.modules:
+        return False
+    if os.environ.get("DISABLE_BG_SCRAPE", "").lower() in ("1", "true", "yes"):
+        return False
+    return os.environ.get("ENABLE_BG_SCRAPE", "1") == "1"
+
+
 # ─── Startup ──────────────────────────────────────────────────────
 init_db(DB_PATH)
-# Note: No background thread — GitHub Actions cron is the scheduler.
-# The /api/scrape endpoint can be called manually or by Actions to trigger a scrape.
+
+if _should_run_bg_scraper():
+    threading.Thread(
+        target=_bg_scrape_loop,
+        daemon=True,
+        name="bg-scrape-loop",
+    ).start()
+else:
+    log.info("Background scraper disabled (DISABLE_BG_SCRAPE set or running under pytest)")
 
 
 def main():

--- a/backend/tests/test_scrape_status.py
+++ b/backend/tests/test_scrape_status.py
@@ -146,16 +146,17 @@ def test_try_start_after_finish():
 
 
 def test_watchdog_stale_reset():
-    """If started_at is older than WATCHDOG_SECONDS, is_running() returns False
-    even if the internal flag is still True (auto-reset)."""
+    """If last_tick_at is older than WATCHDOG_SECONDS, is_running() returns
+    False even if the internal flag is still True (auto-reset)."""
     b = StatusBroker()
     b.start("fast", total=5)
     assert b.is_running() is True
 
-    # Backdate started_at to just past the watchdog window.
+    # Backdate both timestamps to just past the watchdog window.
     stale = datetime.now(timezone.utc) - timedelta(seconds=WATCHDOG_SECONDS + 30)
     with b._lock:
-        b._state["started_at"] = stale.isoformat()
+        b._state["started_at"]   = stale.isoformat()
+        b._state["last_tick_at"] = stale.isoformat()
         # Keep the flag True to prove the watchdog overrides it.
         assert b._state["is_running"] is True
 
@@ -163,3 +164,137 @@ def test_watchdog_stale_reset():
     # The watchdog should also have flipped the underlying flag.
     snap = b.snapshot()
     assert snap["is_running"] is False
+
+
+def test_watchdog_respects_recent_tick():
+    """A scrape that started long ago but is still ticking must NOT be
+    auto-killed — this protects healthy long runs from being treated as
+    crashed. Regression test for the watchdog tracking last activity, not
+    just started_at."""
+    b = StatusBroker()
+    b.start("fast", total=200)
+
+    # Backdate started_at to well past the watchdog — but keep last_tick_at fresh.
+    old = datetime.now(timezone.utc) - timedelta(seconds=WATCHDOG_SECONDS + 120)
+    with b._lock:
+        b._state["started_at"] = old.isoformat()
+    # A real recent tick.
+    b.tick("Anthropic", found_delta=1, new_delta=0)
+
+    # Scrape is still alive — watchdog must NOT trip.
+    assert b.is_running() is True
+
+
+# ─── #20: server-level integration tests ────────────────────────────
+
+
+def _make_test_client(tmp_path):
+    """Spin up the Flask app with an isolated DB. Background scrape thread
+    self-disables under pytest, so the only writer to the broker is the
+    request thread spawned by /api/scrape."""
+    import importlib
+    db_path = str(tmp_path / "test.db")
+    from storage.db import init_db
+    init_db(db_path)
+    import server
+    importlib.reload(server)  # picks up fresh module state + DB_PATH override
+    server.DB_PATH = db_path
+    # Reset the shared broker so previous tests don't leak running state in.
+    from core.scrape_status import broker as shared_broker
+    shared_broker.__init__()
+    server.app.config["TESTING"] = True
+    return server, shared_broker
+
+
+def test_concurrent_scrape_requests(tmp_path, monkeypatch):
+    """Two POSTs /api/scrape in rapid succession: one wins with 202, the
+    other is rejected with 409. The async worker is stubbed so the test
+    stays hermetic — we only validate the broker gating and HTTP status
+    codes. The first request arms the broker before returning, so a
+    sequential second POST is sufficient to prove gating; we don't need
+    concurrent threads sharing the test_client (which has known
+    context-bleed problems across threads in Flask 3+)."""
+    server, b = _make_test_client(tmp_path)
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def _slow_worker(mode="fast"):
+        # Don't call broker.start() here — the route handler's try_start()
+        # already armed it. Just hold the run open until the test releases us.
+        started.set()
+        release.wait(timeout=3)
+        b.finish({"new": 0})
+
+    monkeypatch.setattr(server, "_run_scrape_async", _slow_worker)
+
+    c = server.app.test_client()
+    # First POST: arms the broker synchronously inside try_start() and spawns
+    # the (stubbed) worker that holds is_running=True.
+    r1 = c.post("/api/scrape")
+    # Worker has started — broker is now is_running=True
+    assert started.wait(timeout=2), "worker thread never ran"
+
+    # Second POST happens while the worker is still alive — must 409.
+    r2 = c.post("/api/scrape")
+
+    # Let the worker wind down so a stale daemon thread doesn't leak into
+    # the next test.
+    release.set()
+    time.sleep(0.1)
+
+    codes = sorted([r1.status_code, r2.status_code])
+    assert codes == [202, 409], f"expected [202, 409] got {codes}"
+    body409 = (r1 if r1.status_code == 409 else r2).get_json()
+    assert body409["started"] is False
+    assert body409["reason"] == "scrape_in_progress"
+    assert body409["snapshot"]["is_running"] is True
+
+
+def test_background_thread_uses_broker(tmp_path):
+    """The 5-min background scrape loop calls run_scrape(), which drives
+    broker.start/tick/finish. Simulate that flow and assert the snapshot
+    endpoint reflects intermediate progress."""
+    server, b = _make_test_client(tmp_path)
+
+    with server.app.test_client() as c:
+        # Idle: snapshot has is_running=False
+        r = c.get("/api/scrape/status")
+        assert r.status_code == 200
+        assert r.get_json()["is_running"] is False
+
+        # Simulate the background thread starting a cycle and ticking
+        # halfway through. The endpoint must surface the same state any
+        # manual-trigger UI would see.
+        b.start("fast", total=4)
+        b.tick("Anthropic", found_delta=5, new_delta=1)
+        b.tick("OpenAI",    found_delta=3, new_delta=0)
+
+        r = c.get("/api/scrape/status")
+        snap = r.get_json()
+        assert snap["is_running"] is True
+        assert snap["companies_done"] == 2
+        assert snap["companies_total"] == 4
+        assert snap["found"] == 8
+        assert snap["new"] == 1
+        assert snap["current_company"] == "OpenAI"
+        assert snap["mode"] == "fast"
+
+        # And a second POST /api/scrape during the background run must be
+        # gated by the same broker — i.e. background and manual share state.
+        r2 = c.post("/api/scrape")
+        assert r2.status_code == 409
+        body = r2.get_json()
+        assert body["started"] is False
+        assert body["reason"] == "scrape_in_progress"
+        assert body["snapshot"]["is_running"] is True
+
+        # Wind the cycle down — manual triggers should accept again.
+        b.tick("Stripe", found_delta=2)
+        b.tick("Databricks", found_delta=4, new_delta=2)
+        b.finish({"companies": 4, "found": 14, "new": 3, "errors": 0})
+
+        r = c.get("/api/scrape/status")
+        snap = r.get_json()
+        assert snap["is_running"] is False
+        assert snap["final_stats"]["new"] == 3

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -143,6 +143,71 @@ function LogoImg({ name, size = 32, t }) {
   );
 }
 
+/* ═══ Scrape progress bar (Manual Triggers / Monitor tab) ═══
+   Pure-presentational component — hoisted so the admin op cards in #23/#24
+   can reuse it with their own snapshot shape (same {is_running, current_*,
+   *_done, *_total, found, new, eta_seconds} contract). The fill width
+   transitions smoothly between polls so a slow tick doesn't visually
+   stutter. Caller is responsible for hiding/showing it; this component
+   just renders the bar + labels for the given snapshot. */
+function ScrapeProgressBar({ snap, t }) {
+  if (!snap) return null;
+  const total = Math.max(0, snap.companies_total ?? 0);
+  const done  = Math.max(0, Math.min(snap.companies_done ?? 0, total || Infinity));
+  const pct   = total > 0 ? Math.min(100, Math.max(0, (done / total) * 100)) : 0;
+  const eta   = snap.eta_seconds;
+  return (
+    <div style={{marginTop:4}}>
+      <div style={{
+        display:"flex",justifyContent:"space-between",alignItems:"baseline",
+        gap:8,marginBottom:8,fontSize:13,color:t.txS,lineHeight:1.4,
+        flexWrap:"wrap",
+      }}>
+        <div style={{minWidth:0,flex:"1 1 auto",wordBreak:"break-word",overflowWrap:"anywhere"}}>
+          <strong style={{color:t.tx}}>
+            {snap.current_company || "Initializing"}
+          </strong>
+          {" • "}{done}/{total || "?"} companies
+        </div>
+        {eta != null && eta > 0 && total > done && (
+          <div style={{color:t.txM,fontVariantNumeric:"tabular-nums",flexShrink:0}}>
+            ETA {Math.round(eta)}s
+          </div>
+        )}
+      </div>
+      <div
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(pct)}
+        style={{
+          width:"100%",height:10,borderRadius:6,
+          background:t.bd,overflow:"hidden",
+          border:`1px solid ${t.bd}`,
+        }}
+      >
+        <div style={{
+          height:"100%",width:`${pct}%`,
+          background:t.ac,
+          // Transition slightly shorter than the 1.5s poll cadence so the
+          // bar finishes "catching up" right as the next snapshot arrives —
+          // no visible stall, no overshoot.
+          transition:"width 1400ms cubic-bezier(.4,0,.2,1)",
+          borderRadius:6,
+        }}/>
+      </div>
+      <div style={{
+        marginTop:8,fontSize:13,color:t.txS,lineHeight:1.4,
+      }}>
+        {snap.found ?? 0} jobs found
+        {(snap.new ?? 0) > 0 && <> · <span style={{color:t.ok,fontWeight:600}}>{snap.new} new</span></>}
+        {(snap.errors ?? 0) > 0 && <> · <span style={{color:t.er}}>{snap.errors} errors</span></>}
+        {snap.mode && <span style={{color:t.txM}}> · {snap.mode}</span>}
+      </div>
+    </div>
+  );
+}
+
 /* ═══ Role categories ═══ */
 const ROLE_CATS = [
   {id:"de",  label:"Data Engineer",   kw:["data engineer","etl engineer","data pipeline","data infrastructure","big data","analytics platform"]},
@@ -493,13 +558,20 @@ export default function App() {
   const [applications, setApplications] = useState([]);
   const [appLoading, setAppLoading] = useState(false);
 
-  // Manual scrape trigger + live progress polling (#19).
-  // `scraping` reflects "we should keep polling the status endpoint" — set
-  // when the POST returns 202 or 409, and cleared once snapshot.is_running
-  // flips false. `scrapeProgress` is the latest snapshot from /api/scrape/status.
+  // Manual scrape trigger + live progress polling (#19, #20).
+  // `scraping` reflects "we should keep polling the status endpoint at the
+  // fast cadence" — set when the POST returns 202 or 409, or when the slow
+  // passive poller notices a background scrape running. Cleared once
+  // snapshot.is_running flips false. `scrapeProgress` is the latest snapshot
+  // from /api/scrape/status.
   const [scraping,setScraping]         = useState(false);
   const [scrapeMsg,setScrapeMsg]       = useState(null);
   const [scrapeProgress,setScrapeProgress] = useState(null);
+
+  // Show the progress bar when we're actively polling OR the snapshot says
+  // a scrape is in flight (covers the background scrape thread case where
+  // the user never clicked the button).
+  const barVisible = !!(scrapeProgress && scrapeProgress.is_running);
 
   useEffect(() => {
     if (!scraping || !RENDER_API) return;
@@ -514,7 +586,21 @@ export default function App() {
         if (!r.ok) return;
         const snap = await r.json();
         if (cancelled) return;
-        setScrapeProgress(snap);
+        // Guard against stale-response reordering: if a later poll arrives
+        // before an earlier one, drop the older snapshot so the bar can't
+        // jump backwards. Snapshots from the same run carry monotonic
+        // started_at; companies_done is also monotonic within a run.
+        setScrapeProgress(prev => {
+          if (!prev) return snap;
+          if (prev.started_at && snap.started_at && snap.started_at < prev.started_at) {
+            return prev;  // older run, ignore
+          }
+          if (prev.started_at === snap.started_at &&
+              (snap.companies_done ?? 0) < (prev.companies_done ?? 0)) {
+            return prev;  // out-of-order poll within same run
+          }
+          return snap;
+        });
         if (snap && snap.is_running === false) {
           setScraping(false);
           const s = snap.final_stats || {};
@@ -529,6 +615,41 @@ export default function App() {
     const id = setInterval(tick, 1500);
     return () => { cancelled = true; clearInterval(id); };
   }, [scraping]);
+
+  // Passive low-rate poll for background-scrape progress (#20). When the
+  // Monitor tab is mounted but we haven't manually triggered a scrape, ping
+  // the status endpoint every 10s. If it reports is_running=true, flip into
+  // the fast-poll branch above so the bar appears for the background thread
+  // too. Auto-pauses when the tab is hidden.
+  useEffect(() => {
+    if (!RENDER_API || scraping || tab !== "monitor") return;
+    let cancelled = false;
+    const passive = async () => {
+      if (typeof document !== "undefined" && document.hidden) return;
+      try {
+        const r = await fetch(`${RENDER_API}/api/scrape/status`,
+                              { signal: AbortSignal.timeout(5000) });
+        if (!r.ok || cancelled) return;
+        const snap = await r.json();
+        if (cancelled) return;
+        if (snap && snap.is_running) {
+          setScrapeProgress(snap);
+          setScraping(true);  // hand off to the fast poller
+        }
+      } catch (_e) { /* network hiccup, retry next tick */ }
+    };
+    passive();
+    const id = setInterval(passive, 10000);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [scraping, tab]);
+
+  // Auto-clear the result toast 3s after a scrape finishes.
+  useEffect(() => {
+    if (!scrapeMsg || scraping) return;
+    if (!scrapeMsg.startsWith("✅")) return;
+    const id = setTimeout(() => setScrapeMsg(null), 3000);
+    return () => clearTimeout(id);
+  }, [scrapeMsg, scraping]);
 
   const triggerScrape = async () => {
     if (!RENDER_API) {
@@ -1817,23 +1938,17 @@ export default function App() {
                     Kick off an immediate full scrape on the Render server. Takes ~2–3 minutes.
                     {!RENDER_API && <span style={{color:t.er}}> (Set VITE_RENDER_URL to enable)</span>}
                   </div>
-                  <button onClick={triggerScrape} disabled={scraping||!RENDER_API}
-                    style={{padding:"11px 22px",borderRadius:9,border:"none",
-                      background:scraping?t.bgS:(RENDER_API?t.gP:`${t.txM}20`),
-                      color:scraping||!RENDER_API?t.txM:"#fff",
-                      fontSize:14,fontWeight:700,cursor:scraping||!RENDER_API?"not-allowed":"pointer",
-                      fontFamily:"inherit",transition:"all .15s"}}>
-                    {scraping?"⏳ Scraping...":"▶ Run Scrape Now"}
-                  </button>
-                  {scraping && scrapeProgress && scrapeProgress.is_running && (
-                    <div style={{marginTop:10,fontSize:13,color:t.txS,fontWeight:500,lineHeight:1.5}}>
-                      Scraping: <strong style={{color:t.tx}}>{scrapeProgress.current_company || "starting…"}</strong>
-                      {" • "}{scrapeProgress.companies_done}/{scrapeProgress.companies_total} companies
-                      {" • "}{scrapeProgress.found} jobs found
-                      {scrapeProgress.new>0 && <> · <span style={{color:t.ok}}>{scrapeProgress.new} new</span></>}
-                      {scrapeProgress.eta_seconds!=null && scrapeProgress.eta_seconds>0 &&
-                        <> · ETA {Math.round(scrapeProgress.eta_seconds)}s</>}
-                    </div>
+                  {barVisible ? (
+                    <ScrapeProgressBar snap={scrapeProgress} t={t} />
+                  ) : (
+                    <button onClick={triggerScrape} disabled={!RENDER_API}
+                      style={{padding:"11px 22px",borderRadius:9,border:"none",
+                        background:RENDER_API?t.gP:`${t.txM}20`,
+                        color:RENDER_API?"#fff":t.txM,
+                        fontSize:14,fontWeight:700,cursor:RENDER_API?"pointer":"not-allowed",
+                        fontFamily:"inherit",transition:"all .15s"}}>
+                      ▶ Run Scrape Now
+                    </button>
                   )}
                   {scrapeMsg && (
                     <div style={{marginTop:10,fontSize:14,color:scrapeMsg.startsWith("✅")?t.ok:scrapeMsg.startsWith("⏳")||scrapeMsg.startsWith("🚀")?t.wm:t.er,fontWeight:600}}>


### PR DESCRIPTION
## Summary

Wave 2 of the manual-trigger / live-progress PRD (#18). Builds on #19 (broker + status endpoint).

- **Concurrency guard** — `POST /api/scrape` returns `409 {started: false, reason: "scrape_in_progress", snapshot: ...}` when a scrape is already running (atomic `broker.try_start()` gate).
- **Background scrape thread** — new `_bg_scrape_loop` daemon runs every `FAST_INTERVAL` seconds, uses the *same* `try_start` gate as the HTTP handler so manual + background can't double-scrape. Opt-out via `DISABLE_BG_SCRAPE=1`, auto-disabled under pytest.
- **Watchdog hardening** — `is_running()` now keys off `last_tick_at` instead of `started_at`, so a healthy long scrape can't be auto-killed mid-run; only a silent thread is rescued after `WATCHDOG_SECONDS`.
- **Real progress bar UI** — new `ScrapeProgressBar` component (hoisted at module level so #23/#24 admin ops can reuse it). Bar fill smooths between polls with a 1.4s CSS transition; monotonic snapshot guard rejects out-of-order polls so the bar can't jump backwards.
- **Passive 10s poller** on the Monitor tab notices background scrapes and hands off to the fast 1.5s poller, so users see bg progress too.
- **Auto-clearing completion toast** (3s).

## Smoke test output

```
# Two POSTs in rapid succession
HTTP=202   {"started": true,  "snapshot": {"is_running": true,  ...}}
HTTP=409   {"started": false, "reason": "scrape_in_progress", "snapshot": {"is_running": true, ...}}
```

```
# pytest backend/tests/test_scrape_status.py -v
10 passed in 0.36s
  test_lifecycle / test_concurrent_ticks / test_snapshot_during_write
  test_finish_without_start / test_try_start_rejects_concurrent_starts
  test_try_start_after_finish / test_watchdog_stale_reset
  test_watchdog_respects_recent_tick (NEW)
  test_concurrent_scrape_requests (NEW)
  test_background_thread_uses_broker (NEW)

# Full suite
78 passed in 1.36s
```

```
# Frontend
✓ 829 modules transformed
dist/index.html                  1.09 kB
dist/assets/index-Bxyng02v.js  622.48 kB │ gzip: 175.86 kB
✓ built in 2.78s
```

## Self-critique findings + fixes

Three parallel reviewers were spawned. Real issues found:

1. **(Agent A + Agent C) BG loop's check-then-call was non-atomic.** Original draft did `if broker.is_running(): skip; else: _run_scrape_async(...)`. A manual `POST /api/scrape` could win the broker between the check and the call → two concurrent scrapes ticking the same broker. **Fixed** by switching the bg loop to `broker.try_start("fast", _count_fast_companies())`, mirroring the HTTP handler exactly. Both paths now use the same atomic gate.
2. **(Agent A) Watchdog could auto-kill a healthy long scrape.** Original watchdog used `started_at` only; a real 11-min scrape (cold Render + retries) would have been treated as wedged and a second trigger could spawn a duplicate. **Fixed** by tracking `last_tick_at` on every `tick()` and making the watchdog key off that. Added `test_watchdog_respects_recent_tick` regression test.
3. **(Agent B) Mobile + poll-lag UX.** Long company names could overflow at 480px; the 600ms CSS transition finished well before the 1.5s poll cadence, causing visible stalls. **Fixed:** added `wordBreak:"break-word"` to the company-name slot and bumped the transition to 1400ms so the fill smoothly catches up just as the next snapshot arrives.

No outstanding issues from the reviewers. The `ScrapeProgressBar` component is hoisted and reusable for #23/#24 — only the literal labels `"companies"` and `"jobs found"` would need to become props if a non-scrape op wants different copy (small extension, not a blocker).

## Test plan

- [x] `pytest backend/tests/` — 78 passed
- [x] `python -m py_compile backend/server.py backend/core/scrape_status.py`
- [x] `npm run build` — clean
- [x] Smoke: two concurrent `POST /api/scrape` → 202 + 409 with proper payload
- [x] Smoke: `GET /api/scrape/status` reflects broker state mid-cycle
- [ ] Manual UI verification on a real Render deployment (cannot run a browser in this env)

Closes #20

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLoiR4P9EZAzz6XibgXt5x)_