### PR TITLE
docs: reflect Manual Triggers Reliability Sprint outcomes (closes #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Zero-cost, real-time job scraper + intelligent React dashboard built for data en
 | **"Applied here" badge** | Expand any job card to see your history at that company |
 | **Profile & PIN** | Store preferences, dream companies, access PIN via Render API |
 | **Mobile responsive** | Works on phone, tablet, desktop |
-| **Manual triggers** | Dashboard button + GitHub Actions dispatch |
+| **Manual triggers panel** | Live progress bar + concurrency-safe scrape + 5 admin ops (Doctor, Purge, Re-extract, Vault Re-index, Clear Cache) |
+| **Live scrape progress** | Real-time polling: current company, completed/total, jobs found, ETA |
+| **Doctor health-check** | One-click readiness probe: DB, scrapers, recent runs, env vars, vault, disk |
 | **Dark / Light theme** | Persists in memory |
 
 ## Architecture
@@ -239,20 +241,65 @@ curl https://your-render-url.onrender.com/api/applications/company/Goldman%20Sac
 
 ---
 
-## Manual Triggers
+## Manual Triggers Panel (Monitor tab)
 
-### Dashboard (Monitor tab)
-- **Trigger Render Scrape** — kicks off a full scrape on Render immediately
-- **Open GitHub Actions** — link to run the workflow manually (full or fast mode)
+The dashboard ships a six-card maintenance panel for live operations. Every card respects the same `API_SECRET` Bearer auth as `/api/scrape`.
 
-### GitHub Actions (manual dispatch)
-Go to: `Actions → Full Sweep & Deploy → Run workflow`
-- Choose `full` (all 130+ companies, ~3 min) or `fast` (Tier 1 only, ~30 sec)
+| Card | What it does | Endpoint |
+|------|--------------|----------|
+| 🚀 **Trigger Render Scrape** | Fires a fast scrape (Tier 1, ~30s). Returns `202` and starts streaming live progress (current company, X/Y companies, jobs found). Returns `409` if a scrape is already running; UI shows the running scrape's progress bar instead of the button. | `POST /api/scrape` + `GET /api/scrape/status` |
+| ⚡ **Trigger GitHub Actions** | External link to the workflow manual dispatch (full or fast). | — |
+| 🩺 **Doctor** | Health-check probe: DB connectivity, all 6 scrapers importable, recent successful scrape run, env vars, vault dirs writable, disk space. Each check returns pass/warn/fail. | `GET /api/admin/doctor` |
+| 🗑️ **Purge Stale Jobs** | Deletes inactive jobs older than N hours (default 96). Returns count. Refuses (`409`) during an active scrape. Confirm dialog before fire. | `POST /api/admin/purge-stale` |
+| 🧠 **Re-extract Skills** | Reruns skill extraction across all stored resume versions. Returns count updated. | `POST /api/admin/reextract-skills` |
+| 📚 **Vault Re-index** | Rebuilds the in-memory TF-IDF index from `resume_vault/text/`. Returns count + duration. | `POST /api/admin/vault-reindex` |
+| ♻️ **Clear DB Cache** | Runs `VACUUM` on the SQLite DB. Returns bytes reclaimed. Refuses (`409`) during an active scrape. Confirm dialog before fire. | `POST /api/admin/clear-cache` |
 
-### API
+### Live Progress Architecture
+
+```
+                 broker.start(mode, total)
+                 broker.tick(company, found, new)
+                 broker.finish(stats)
+                       │
+            ┌──────────┴──────────┐
+            │                     │
+   /api/scrape (manual)     5-min background thread
+            │                     │
+            └─────────┬───────────┘
+                      ▼
+               core/scrape_status.py (singleton broker)
+                      ▲
+                      │ GET /api/scrape/status (1.5s polling)
+                      │
+                Frontend progress bar
+```
+
+A single thread-safe broker (`core/scrape_status.py`) tracks scrape state. Both the manual trigger and the 5-min cron report through it. The broker has a 10-min watchdog — if a scrape thread dies without calling `finish()`, the next status read reports `is_running: false`.
+
+### Backend CLI
+
 ```bash
+# Manual scrape — same orchestrator, no progress feedback
+python main.py            # full sweep (all 130+ companies)
+python main.py --fast     # Tier 1 only (~30 sec)
+
+# Adjust per-request delay (formerly the --delay flag; now an env var)
+SCRAPE_DELAY=0.5 python main.py --fast
+```
+
+### Direct API
+
+```bash
+# Trigger scrape (returns 202 with snapshot, or 409 if running)
 curl -X POST https://your-render-url.onrender.com/api/scrape \
   -H "Authorization: Bearer YOUR_API_SECRET"
+
+# Poll status (returns broker snapshot)
+curl https://your-render-url.onrender.com/api/scrape/status
+
+# Run doctor (read-only health-check)
+curl https://your-render-url.onrender.com/api/admin/doctor | python -m json.tool
 ```
 
 ---
@@ -274,15 +321,22 @@ job-scout/
 │   │   ├── workday.py           # 7 finance companies
 │   │   └── utils.py             # shared HTTP helpers
 │   ├── core/
-│   │   └── relevance.py         # Keyword scoring engine (0–100%)
+│   │   ├── relevance.py          # Keyword scoring engine (0–100%)
+│   │   ├── scrape_orchestrator.py # Canonical run_scrape() — shared by CLI + server
+│   │   └── scrape_status.py      # Thread-safe broker for live progress
+│   ├── routes/
+│   │   ├── vault_routes.py       # 8 resume-vault endpoints
+│   │   └── admin_routes.py       # Doctor + 5 destructive/maintenance ops
 │   ├── storage/
-│   │   ├── db.py                # SQLite: jobs + applications + resume_versions
-│   │   └── profile_manager.py   # Profile + resume storage + skill extraction
+│   │   ├── db.py                 # SQLite: jobs + applications + resume_versions
+│   │   ├── db_admin.py           # Purge + VACUUM helpers used by admin_routes
+│   │   ├── profile_manager.py    # Profile + resume storage + skill extraction
+│   │   └── resume_vault.py       # PDF vault + TF-IDF engine
 │   ├── alerts/
-│   │   └── notifier.py          # Discord + Telegram dream-job alerts
-│   ├── server.py                # Flask API + background scraper + night skip
-│   ├── main.py                  # CLI (GitHub Actions + local testing)
-│   ├── export_data.py           # DB → api-data.json
+│   │   └── notifier.py           # Discord + Telegram dream-job alerts
+│   ├── server.py                 # Flask API + background scraper + night skip
+│   ├── main.py                   # CLI (GitHub Actions + local testing)
+│   ├── export_data.py            # DB → api-data.json
 │   └── requirements.txt
 ├── frontend/
 │   ├── src/

--- a/specs/README.md
+++ b/specs/README.md
@@ -21,31 +21,72 @@ This file is the persistent project context for agents and maintainers.
 
 ## Architecture and Design Constraints
 
-- Document hard constraints: security, latency, data boundaries, platform limits.
-- Explicitly call out non-goals so agents do not overbuild.
+- **Render free tier**: single gunicorn worker, no persistent disk beyond ephemeral container, sleeps after 15 min idle (mitigated by 14-min GitHub Actions keepalive).
+- **SQLite WAL mode** for the jobs/applications DB — single-writer assumption holds. Background scrape thread + manual trigger share one DB via the orchestrator; concurrency guard prevents double-writers.
+- **Zero new runtime deps** for the Manual Triggers sprint — `threading.RLock`, stdlib `shutil.disk_usage`, no SSE/WebSocket libraries.
+- **All admin operations honor `API_SECRET` Bearer auth** — same pattern as `/api/scrape`. No new auth surface.
+- **Non-goals**: mode picker in dashboard (always-fast), real `gh workflow run` integration (stays as external link), SSE streaming (polling at 1.5s is sufficient), splitting `server.py` into per-concern modules.
 
 ## Built So Far
 
-- Summarize current shipped capabilities and important in-progress slices.
-- Prefer concrete status over aspiration.
+**Discovery layer (live):**
+- 130+ companies scraped across 6 ATS platforms (Greenhouse, Lever, Ashby, SmartRecruiters, BambooHR, Workday) every 5 min on Render + every 2 hr on GitHub Actions.
+- Multi-signal relevance engine + TF-IDF resume booster + per-tier alert thresholds + Playwright extension for locked APIs.
+- Discord + Telegram dream-job alerts (free forever).
+
+**Manual Triggers Reliability Sprint — 2026-05-15 (PRD #18, all 6 children shipped):**
+- **Thread-safe scrape status broker** (`core/scrape_status.py`) — singleton with `start/tick/finish/snapshot/is_running` + 10-min stale-run watchdog.
+- **Consolidated `run_scrape()`** into `core/scrape_orchestrator.py` — single canonical signature `run_scrape(conn, *, mode='fast', status_broker=None)`. CLI and Flask server both import from here. `delay` moved from arg to `SCRAPE_DELAY` env var.
+- **Live progress UI** — `GET /api/scrape/status` returns the broker snapshot; frontend polls every 1.5s; renders a progress bar with current company, X/Y companies, jobs found, ETA.
+- **Concurrency guard** — `POST /api/scrape` returns `409` with snapshot if a scrape is already running. The 5-min cron thread also reports through the broker, so manual users see its progress in real time.
+- **Admin Blueprint** (`routes/admin_routes.py`) with 5 endpoints, all under `/api/admin/`:
+  - `GET /doctor` — 6-probe health-check (DB, scrapers, recent run, env, vault, disk).
+  - `POST /purge-stale` — deletes inactive jobs older than N hours (default 96). 409 during active scrape.
+  - `POST /clear-cache` — VACUUM the SQLite DB. 409 during active scrape.
+  - `POST /reextract-skills` — re-runs skill extraction over `resume_versions` rows.
+  - `POST /vault-reindex` — rebuilds the in-memory TF-IDF matrix from `resume_vault/text/`.
+- **6-card Manual Triggers panel** in `frontend/src/App.jsx` Monitor tab — scrape + 5 admin ops + GitHub Actions link.
+- **pytest coverage** — first real test suite in the repo: `test_scrape_status.py`, `test_scrape_orchestrator.py`, `test_admin_routes.py` (covering broker thread-safety, orchestrator regression, doctor aggregation, purge/clear-cache during scrape guard).
+
+**Resume vault layer (live, ❌ no dashboard UI yet):**
+- 95 PDF resume vault + filename parser (150+ naming patterns) + TF-IDF cosine-similarity engine.
+- 8 vault endpoints under `/api/vault/`. Frontend integration deferred (see Open Issues).
 
 ## Design Decisions
 
-- Record decisions with short rationale and trade-offs.
-- Keep this as the canonical ADR-lite trail for this repo.
+- **Broker as singleton, not request-scoped** — Render runs a single gunicorn worker; the background scrape thread and Flask handlers all share the same process. A module-level `broker = StatusBroker()` is the simplest correct shape. If we ever go multi-worker, we'd need to externalize state (Redis or DB column).
+- **10-min watchdog inside `is_running()`** rather than a separate cleanup thread — keeps the broker fully synchronous and stdlib-only. Cost: an extra wall-clock check per `is_running()` call (negligible).
+- **Polling over SSE** — 1.5s polling is cheap on Render's free tier and avoids the keepalive complexity of long-lived connections behind their proxy. Each `/api/scrape/status` call is <50ms.
+- **`SCRAPE_DELAY` env var, not function arg** — eliminated the original bug (drift between CLI `delay` and server hardcoded `SCRAPE_DELAY`). One env var, one read path, one canonical signature.
+- **Admin Blueprint mirrors `vault_routes.py`** — same pattern, same auth, same response JSON shape. New endpoints feel like the existing surface.
+- **Destructive admin ops check `broker.is_running()` and return 409** — prevents `VACUUM`/`DELETE` lock contention with the scrape's `UPDATE` traffic. Non-destructive ops (re-extract, reindex) don't need the guard.
+- **Self-critique gate on every PR** — 3 parallel Agent calls (Sanity / Production / Architecture) before commit. Caught real issues during the sprint (e.g., daemon thread leak, missing min() clamp). Repeated across all 6 children.
 
 ## What Worked
 
-- Capture patterns that produced reliable progress and quality.
+- **Vertical-slice decomposition** (PDD → `/prd-to-issues`) — 6 thin end-to-end slices on 2 parallel tracks beat 5 horizontal layers. Tracers (#19, #22) de-risked the architecture before fan-out (#20, #21, #23, #24) all merged with only additive `CHANGELOG.md` + `App.jsx` conflicts.
+- **Parallel RemoteTrigger fleet** — two tracers fired simultaneously (#19 + #22), then four Wave-2 issues fanned out in parallel. Self-critique baked into each prompt prevented agents from shipping unreviewed code.
+- **Conflict pattern was always additive** — every cross-PR conflict in this sprint was an "add a line to a Markdown list" or "add a new admin card to the same JSX panel". Resolving with `--force-with-lease` after each merge worked cleanly.
+- **Test surface added per slice** — first pytest suite in the repo arrived as a side effect of the sprint, not as a separate "add tests" issue. Each child PR carried its own tests.
 
 ## What Failed or Was Reverted
 
-- Capture dead ends, regressions, and reversals so new agents avoid repeats.
+- **PR #14 + #17 (relevance overhaul scoring + UI signals, 2026-05-15 earlier)** — auto-close trailers were missed, causing issues #7/#10/#11 to stay open after their PRs merged. **Lesson:** when bundling multiple issues in one PR, use the literal `Closes #N, Closes #M, Closes #O` syntax on separate lines in the PR body, not a single combined phrase. (Manually closed during cleanup.)
+- **Force-push pre-action hook blocked the rebase workflow** initially during the Manual Triggers sprint. Resolved by user-authorized `--force-with-lease`. **Lesson:** for PR-branch rebases (own branches, no shared collaborators), `--force-with-lease` is the safe-force variant and should be allowlisted in the hook.
 
 ## Open Issues and Next Work
 
-- List open issues, next priority, and implementation order.
-- Keep this section actionable and current before compaction.
+**Open issues (post-sprint):**
+- **#18** — PRD: Manual Triggers Reliability Sprint. All 6 children merged. **Manually close after this commit lands** (no PR references the PRD directly).
+- **#1** — `[Feature] Automatic application tracking via email parsing + extension events` (older backlog, separate sprint).
+- **#2, #3, #4** — Older Relevance #1, #2, #3 issues (older work; verify if shipped, close if so).
+
+**Recommended next priorities:**
+1. **Vault UI integration** — the resume vault has 8 live endpoints + 95 indexed PDFs but no dashboard frontend. First slice: wire `POST /api/vault/best-match` into job cards so clicking a job surfaces the best-matching resume.
+2. **Wave-3 cleanup** — close #18, audit #2/#3/#4 status, file a 1-line follow-up if `db_admin.py` or any sprint module needs hardening based on first-week production use.
+3. **AutoApply AI integration** — separate repo (`autoapply-ai`); see `CLAUDE.md` for the end-to-end vision (Chrome extension reads form fields, FastAPI backend generates answers via multi-LLM pipeline, JobScout vault picks the right resume).
+
+## How To Work in This Repo
 
 ## How To Work in This Repo
 


### PR DESCRIPTION
## Summary

Post-sprint documentation update reflecting the Manual Triggers Reliability Sprint (PRD #18). All 6 child issues (#19–#24) merged today; this PR brings the user-facing `README.md` and the engineering-memory `specs/README.md` up to date with what shipped.

### README.md changes
- Features table: replace single "Manual triggers" row with three rows (6-card panel, live scrape progress, Doctor health-check).
- Rewrite the **Manual Triggers Panel** section as a per-card table (scrape + 5 admin ops + GitHub Actions link), with endpoints listed inline.
- Add a live-progress architecture diagram showing how `core/scrape_status.py` broker is shared between the manual handler and the 5-min background thread.
- Add CLI notes: `SCRAPE_DELAY` env var replaces the old `--delay` arg.
- Add direct-API `curl` examples for `/api/scrape`, `/api/scrape/status`, `/api/admin/doctor`.
- Update File Structure with new modules: `core/scrape_orchestrator.py`, `core/scrape_status.py`, `routes/admin_routes.py`, `storage/db_admin.py`, plus existing `routes/vault_routes.py` and `storage/resume_vault.py` that were already in the repo.

### specs/README.md changes
Fill in the previously-skeleton sections with concrete content:
- **Architecture and Design Constraints**: Render single-worker, SQLite WAL, zero-new-deps decision, explicit non-goals.
- **Built So Far**: full sprint inventory (broker, orchestrator, live UI, concurrency guard, admin Blueprint with 5 endpoints, pytest suite arrived).
- **Design Decisions**: ADR-lite trail covering broker-as-singleton, 10-min watchdog inside `is_running()`, polling-over-SSE, `SCRAPE_DELAY` env var, admin Blueprint mirroring `vault_routes.py`, destructive-op 409 guard pattern, mandatory self-critique gate.
- **What Worked**: vertical-slice decomposition (PDD), parallel RemoteTrigger fleet, additive conflicts, per-slice test surface.
- **What Failed**: auto-close trailer miss on bundled-issue PRs (#7/#10/#11 had to be closed manually), force-push hook friction.
- **Open Issues and Next Work**: PRD #18 to close, vault UI integration as next priority, AutoApply AI vision.

Closes #18 — completes the Manual Triggers Reliability Sprint with documentation aligned to shipped behavior.

## Test plan

- [x] Markdown renders correctly (no broken table syntax, code fences balanced)
- [x] All cited file paths exist in `main` (verified against this branch's tree)
- [x] All cited endpoints (`/api/scrape/status`, `/api/admin/doctor`, etc.) exist in the merged code
- [x] No behavioral code change — docs-only PR; no tests to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
