### PR TITLE
feat(vault): add top_n parameter to /api/vault/best-match (#38)

### DIFF
--- a/backend/routes/vault_routes.py
+++ b/backend/routes/vault_routes.py
@@ -29,6 +29,28 @@ vault_bp = Blueprint("vault", __name__)
 
 DB_PATH = os.environ.get("DB_PATH", os.path.join(os.path.dirname(__file__), "..", "jobscout.db"))
 
+_TOP_N_CAP = 50
+
+
+def _parse_top_n(raw):
+    """Return validated top_n int (1..cap), or None for "use default = all".
+
+    Lenient on garbage types (bool, non-integral float, str, list, dict, <=0):
+    callers get all rankings. Strict on overflow: ``raw > _TOP_N_CAP`` raises
+    ``ValueError`` so the route can return 400.
+    """
+    if raw is None or isinstance(raw, bool):
+        return None
+    if isinstance(raw, float):
+        if not raw.is_integer():
+            return None
+        raw = int(raw)
+    if not isinstance(raw, int) or raw <= 0:
+        return None
+    if raw > _TOP_N_CAP:
+        raise ValueError(raw)
+    return raw
+
 
 @vault_bp.route("/api/vault/upload", methods=["POST", "OPTIONS"])
 def vault_upload():
@@ -170,7 +192,16 @@ def vault_best_match():
     Rank all resume versions against a job description. Best fit first.
 
     JSON body:
-        {"job_description": "We are looking for a Senior Data Engineer..."}
+        {
+            "job_description": "We are looking for a Senior Data Engineer...",
+            "top_n": 5    // optional, positive int <= 50; slices the rankings
+        }
+
+    Response:
+        {"count": <total resumes scanned>, "rankings": [... up to top_n entries ...]}
+
+    `count` always reflects the total number of resumes scanned (not the
+    sliced length), so callers can tell whether more results exist.
     """
     if request.method == "OPTIONS":
         return "", 200
@@ -182,8 +213,17 @@ def vault_best_match():
     if not jd:
         return jsonify({"error": "job_description required"}), 400
 
+    raw_top_n = data.get("top_n")
+    try:
+        top_n = _parse_top_n(raw_top_n)
+    except ValueError:
+        return jsonify({
+            "error": f"top_n must be <= {_TOP_N_CAP} (got {raw_top_n})"
+        }), 400
+
     results = find_best_resume_for_job(jd, db_path=DB_PATH)
-    return jsonify({"count": len(results), "rankings": results}), 200
+    rankings = results[:top_n] if top_n is not None else results
+    return jsonify({"count": len(results), "rankings": rankings}), 200
 
 
 @vault_bp.route("/api/vault/stats", methods=["GET"])

--- a/backend/tests/test_vault_routes.py
+++ b/backend/tests/test_vault_routes.py
@@ -157,34 +157,57 @@ def test_best_match_top_n_integral_float_slices(client):
     assert len(data["rankings"]) == 5
 
 
+def test_best_match_top_n_integral_float_at_cap_slices(client):
+    """top_n=50.0 → integral float at the cap; coerced to int(50), accepted (not 400).
+
+    Boundary case: float-at-cap must NOT fall into the lenient bucket and must
+    NOT raise the over-cap 400. With 10 mock resumes, ``rankings[:50]`` returns
+    all 10.
+    """
+    resp = client.post(
+        "/api/vault/best-match",
+        json={"job_description": "Python", "top_n": 50.0},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 10
+    assert len(data["rankings"]) == 10
+
+
 # --- Lenient inputs -> treated as absent ------------------------------
 
 
 @pytest.mark.parametrize(
     "bad_top_n",
     [
-        0,             # zero
-        -1,            # negative int
-        "foo",         # string
-        "5",           # numeric string — still a string
-        True,          # bool True (Python treats as int 1, but we reject bools)
-        False,         # bool False — the OTHER bool, round 1 only tested True
-        5.7,           # non-integral float
-        0.5,           # non-integral fractional float
-        [],            # list
-        [5],           # non-empty list
-        {},            # empty dict
-        {"n": 5},      # dict
+        0,                # zero
+        -1,               # negative int
+        "foo",            # string
+        "5",              # numeric string — still a string
+        "DROP TABLE",     # string with spaces / SQL-ish — still a string
+        True,             # bool True (Python treats as int 1, but we reject bools)
+        False,            # bool False — the OTHER bool, round 1 only tested True
+        5.7,              # non-integral float
+        0.5,              # non-integral fractional float
+        float("inf"),     # +inf — is_integer() → False → lenient
+        float("nan"),     # nan — is_integer() → False → lenient
+        [],               # list
+        [5],              # non-empty list
+        {},               # empty dict
+        {"n": 5},         # dict
     ],
     ids=[
         "zero",
         "negative",
         "string_alpha",
         "string_numeric",
+        "string_text",
         "bool_true",
         "bool_false",
         "float_non_integral",
         "float_fractional",
+        "float_inf",
+        "float_nan",
         "list_empty",
         "list_nonempty",
         "dict_empty",

--- a/backend/tests/test_vault_routes.py
+++ b/backend/tests/test_vault_routes.py
@@ -1,0 +1,265 @@
+"""Tests for /api/vault/best-match — focuses on the `top_n` slicing parameter (issue #38)."""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+# --- Fixtures ---------------------------------------------------------
+
+
+def _make_fake_ranker(n):
+    """Build a deterministic ``find_best_resume_for_job`` stub returning ``n`` rows."""
+    def fake_find_best(job_description, db_path=None):
+        return [
+            {
+                "version_key": f"v{i}",
+                "display_name": f"Resume {i}",
+                "combined_score": round(1.0 - i * 0.05, 4),
+                "tfidf_similarity": 0.5,
+                "skill_match_pct": 80 - i,
+                "matched_skills": ["python", "sql"],
+                "missing_skills": [],
+            }
+            for i in range(n)
+        ]
+    return fake_find_best
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    """Flask test client backed by a hermetic DB; 10-resume ranker by default."""
+    db_path = str(tmp_path / "test.db")
+    from storage.db import init_db
+    init_db(db_path)
+
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.delenv("API_SECRET", raising=False)
+
+    for mod in ["routes.vault_routes", "server"]:
+        if mod in sys.modules:
+            del sys.modules[mod]
+
+    import server
+    server.DB_PATH = db_path
+    server.app.config["TESTING"] = True
+
+    import storage.resume_vault as rv
+    monkeypatch.setattr(rv, "find_best_resume_for_job", _make_fake_ranker(10))
+
+    with server.app.test_client() as c:
+        yield c
+
+
+@pytest.fixture
+def empty_client(tmp_path, monkeypatch):
+    """Variant of ``client`` whose ranker returns ``[]`` (empty vault)."""
+    db_path = str(tmp_path / "empty.db")
+    from storage.db import init_db
+    init_db(db_path)
+
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.delenv("API_SECRET", raising=False)
+
+    for mod in ["routes.vault_routes", "server"]:
+        if mod in sys.modules:
+            del sys.modules[mod]
+
+    import server
+    server.DB_PATH = db_path
+    server.app.config["TESTING"] = True
+
+    import storage.resume_vault as rv
+    monkeypatch.setattr(rv, "find_best_resume_for_job", _make_fake_ranker(0))
+
+    with server.app.test_client() as c:
+        yield c
+
+
+# --- No top_n / absent -> returns all ---------------------------------
+
+
+def test_best_match_no_top_n_returns_all(client):
+    """No `top_n` in body → return full ranking (current behavior preserved)."""
+    resp = client.post("/api/vault/best-match", json={"job_description": "Python SQL Spark Kafka"})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 10
+    assert len(data["rankings"]) == 10
+
+
+def test_best_match_null_top_n_returns_all(client):
+    """top_n: null → treated as absent."""
+    resp = client.post(
+        "/api/vault/best-match",
+        json={"job_description": "Python", "top_n": None},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 10
+    assert len(data["rankings"]) == 10
+
+
+# --- Valid top_n -> slices --------------------------------------------
+
+
+def test_best_match_top_n_3_returns_3(client):
+    """top_n=3 → exactly 3 rankings returned; count still reflects total scanned."""
+    resp = client.post(
+        "/api/vault/best-match",
+        json={"job_description": "Python", "top_n": 3},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 10  # total scanned, NOT the slice length
+    assert len(data["rankings"]) == 3
+    # Slicing preserves order (best fit first).
+    assert data["rankings"][0]["version_key"] == "v0"
+    assert data["rankings"][2]["version_key"] == "v2"
+
+
+def test_best_match_top_n_1_returns_1(client):
+    """top_n=1 → only the top match."""
+    resp = client.post(
+        "/api/vault/best-match",
+        json={"job_description": "Python", "top_n": 1},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 10
+    assert len(data["rankings"]) == 1
+    assert data["rankings"][0]["version_key"] == "v0"
+
+
+def test_best_match_top_n_larger_than_total_returns_all(client):
+    """top_n=50 but only 10 resumes exist → returns all 10 (no padding/error)."""
+    resp = client.post(
+        "/api/vault/best-match",
+        json={"job_description": "Python", "top_n": 50},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 10
+    assert len(data["rankings"]) == 10
+
+
+def test_best_match_top_n_integral_float_slices(client):
+    """top_n=5.0 → coerced to int(5), slices to 5 (new in round 2)."""
+    resp = client.post(
+        "/api/vault/best-match",
+        json={"job_description": "Python", "top_n": 5.0},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 10
+    assert len(data["rankings"]) == 5
+
+
+# --- Lenient inputs -> treated as absent ------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_top_n",
+    [
+        0,             # zero
+        -1,            # negative int
+        "foo",         # string
+        "5",           # numeric string — still a string
+        True,          # bool True (Python treats as int 1, but we reject bools)
+        False,         # bool False — the OTHER bool, round 1 only tested True
+        5.7,           # non-integral float
+        0.5,           # non-integral fractional float
+        [],            # list
+        [5],           # non-empty list
+        {},            # empty dict
+        {"n": 5},      # dict
+    ],
+    ids=[
+        "zero",
+        "negative",
+        "string_alpha",
+        "string_numeric",
+        "bool_true",
+        "bool_false",
+        "float_non_integral",
+        "float_fractional",
+        "list_empty",
+        "list_nonempty",
+        "dict_empty",
+        "dict_nonempty",
+    ],
+)
+def test_best_match_lenient_garbage_types_return_all(client, bad_top_n):
+    """Garbage / out-of-domain top_n values → lenient: ignore and return all."""
+    resp = client.post(
+        "/api/vault/best-match",
+        json={"job_description": "Python", "top_n": bad_top_n},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 10
+    assert len(data["rankings"]) == 10
+
+
+# --- Over-cap -> 400 --------------------------------------------------
+
+
+def test_best_match_top_n_over_cap_returns_400(client):
+    """top_n=999 → 400 (abuse-prevention cap); error names cap and received value."""
+    resp = client.post(
+        "/api/vault/best-match",
+        json={"job_description": "Python", "top_n": 999},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data["error"] == "top_n must be <= 50 (got 999)"
+
+
+def test_best_match_top_n_51_returns_400(client):
+    """top_n=51 → just over the cap, 400; error includes received value."""
+    resp = client.post(
+        "/api/vault/best-match",
+        json={"job_description": "Python", "top_n": 51},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data["error"] == "top_n must be <= 50 (got 51)"
+
+
+def test_best_match_top_n_50_accepted(client):
+    """top_n=50 → exactly at the cap, accepted."""
+    resp = client.post(
+        "/api/vault/best-match",
+        json={"job_description": "Python", "top_n": 50},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 10
+    assert len(data["rankings"]) == 10  # only 10 exist, so all returned
+
+
+# --- Empty vault ------------------------------------------------------
+
+
+def test_best_match_empty_vault_returns_empty_rankings(empty_client):
+    """Vault returns no rankings → count=0, rankings=[] even with top_n set."""
+    resp = empty_client.post(
+        "/api/vault/best-match",
+        json={"job_description": "Python", "top_n": 5},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 0
+    assert data["rankings"] == []
+
+
+# --- Missing job_description still rejected ---------------------------
+
+
+def test_best_match_missing_jd_still_400(client):
+    """No `job_description` → 400, regardless of top_n."""
+    resp = client.post("/api/vault/best-match", json={"top_n": 5})
+    assert resp.status_code == 400
+    assert "job_description" in resp.get_json()["error"]

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -546,12 +546,12 @@ export default function App() {
       const r = await fetch(`${RENDER_API}/api/vault/best-match`, {
         method:"POST",
         headers:{"Content-Type":"application/json"},
-        body: JSON.stringify({job_description: jd}),
+        body: JSON.stringify({job_description: jd, top_n: 5}),
         signal: AbortSignal.timeout(15000),
       });
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
       const d = await r.json();
-      const rankings = Array.isArray(d.rankings) ? d.rankings.slice(0, 5) : [];
+      const rankings = Array.isArray(d.rankings) ? d.rankings : [];
       setBestMatchByJob(prev => ({...prev, [key]: {loading:false, error:null, data:{count:d.count||0, rankings}}}));
     } catch (e) {
       const msg = (e?.name === "TimeoutError" || /timed out/i.test(e?.message||""))


### PR DESCRIPTION
Closes #38.

## Summary

`POST /api/vault/best-match` now accepts an optional `top_n: <int>` body parameter, capping the returned `rankings` list. The frontend (`fetchBestMatch` in `App.jsx`) sends `top_n: 5` and drops its client-side `.slice(0, 5)`, eliminating ~95% of the per-request egress (90 of 95 rankings were being discarded).

## API contract

Request:
```json
{ "job_description": "...", "top_n": 5 }
```

Response (shape unchanged):
```json
{ "count": 95, "rankings": [ ... up to top_n entries ... ] }
```

- `count` = total resumes scanned (NOT the sliced length — UI uses this to show "Top 5 of 95")
- `rankings.length ≤ top_n` when `top_n` is valid
- Backward-compatible: omitting `top_n` returns all rankings as before

## Validation behavior

A module-private helper `_parse_top_n(raw) -> int | None`:
- Returns the parsed int for valid 1..50 (including integral floats like `5.0`)
- Returns `None` (= "treat as absent") for `None`, `bool`, non-integral floats, non-numeric types, `0`, negatives, NaN, Inf
- Raises `ValueError(raw)` for integers >50, caught by the route which returns `400 {"error": "top_n must be <= 50 (got <value>)"}`

Lenient on garbage types (back-compat for older clients), strict only on the over-cap abuse case.

## Multi-agent workflow

This change went through three rounds of the agent pipeline:

- **Round 1** (2 parallel implementation agents, picked the cleaner one)
- **5 critic lenses**: correctness, tests, security, performance, code quality
- **Round 2**: applied consensus feedback (hoist `_TOP_N_CAP`, extract helper, flatten validation, integral-float coercion, tightened error msg, plain `# ---` test dividers, expanded test coverage)
- **5 critic re-review**: 3/5 ✅ APPROVED, 2/5 ⚠️ APPROVED-WITH-SUGGESTIONS asking only for boundary tests
- **Round 3**: added 4 boundary/adversarial tests (`float('inf')`, `float('nan')`, `"DROP TABLE"` string, `top_n: 50.0` at-cap)
- **Final re-review (tests + security lenses)**: ✅ **5/5 APPROVED** — full consensus

Surfaced one new follow-up during review: **issue #41** (unbounded `job_description` is the real DoS lever; `top_n=50` is a payload cap, not a CPU cap). Out of scope here.

## Test coverage

`backend/tests/test_vault_routes.py` (new, 27 cases):
- Happy paths: no `top_n`, `top_n=1`, `top_n=3` slicing, `top_n=50` at-cap, `top_n=20 > total`
- Lenient on bad types (parametrized): `bool_true`, `bool_false`, `float_non_integral`, `float_fractional`, `float_inf`, `float_nan`, `string_text` ("DROP TABLE"), `list_empty`, `list_nonempty`, `dict_empty`, `dict_nonempty`, `string_numeric`
- Float-at-cap: `top_n=50.0` coerces to 50 and slices
- 400 paths: `top_n=51`, `top_n=999`
- Empty-vault edge: returns `{count:0, rankings:[]}`
- Regression: missing `job_description` still 400

Full backend suite: **125/125 passed in 43.55s**

## Frontend

`fetchBestMatch` now sends `{job_description, top_n: 5}` and consumes `d.rankings` directly. The literal `5` matches the existing per-card "top 5 matches" UI convention in the file.

Build: 646.28 kB / 180.60 kB gzip — unchanged.

## Test plan

- [x] `cd backend && python -m pytest tests/ -x` — 125 passed
- [x] `cd frontend && npm run build` — clean
- [ ] Manual: click "Find Best Resume" on a job card, confirm panel renders top 5 with score bars
- [ ] Manual: confirm the count chip shows "Top 5 of N" (where N is total vault size)
- [ ] Optional: hit `curl -X POST $RENDER/api/vault/best-match -H 'Content-Type: application/json' -d '{"job_description":"test","top_n":51}'` → 400 with friendly error

https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr)_