### PR TITLE
fix(vault): delete removes PDF + text files from disk (#37)

### DIFF
--- a/backend/routes/vault_routes.py
+++ b/backend/routes/vault_routes.py
@@ -249,9 +249,74 @@ def vault_version(version_key):
         return jsonify(rv), 200
 
     elif request.method == "DELETE":
-        from storage.profile_manager import delete_resume_version
-        delete_resume_version(version_key, db_path=DB_PATH)
-        return jsonify({"status": "deleted", "version_key": version_key}), 200
+        # Issue #37: also remove the PDF + text file from disk, otherwise the
+        # entry resurrects on next refresh because list_vault() reads disk.
+        from storage.db import get_conn, get_resume_version
+        from storage.resume_vault import delete_vault_version, list_vault
+
+        # Reject path-traversal-shaped keys BEFORE the existence check so the
+        # response is 400 (malformed) instead of 404 (not found). We also
+        # reject null bytes here — os.path.realpath() raises ValueError on
+        # embedded nulls, and we want a 400 (client error) not a 500.
+        if (
+            "\x00" in version_key
+            or "/" in version_key
+            or "\\" in version_key
+            or ".." in version_key
+        ):
+            return jsonify({"error": f"Invalid version_key: {version_key!r}"}), 400
+
+        # Idempotency (Round 2): if neither a DB row nor any PDF on disk maps
+        # to this key, the resource is already gone. Return 200 with
+        # already_gone:true so retried DELETE calls from queues/clients are
+        # safe. We only 400 on malformed keys (handled above) — 404 is no
+        # longer appropriate because DELETE's post-condition (resource does
+        # not exist) is satisfied.
+        conn = get_conn(DB_PATH)
+        rv = get_resume_version(conn, version_key)
+        conn.close()
+        on_disk = any(f.get("version_key") == version_key for f in list_vault())
+        if not rv and not on_disk:
+            return jsonify({
+                "status": "deleted",
+                "version_key": version_key,
+                "db_row_deleted": False,
+                "pdf_deleted": False,
+                "text_deleted": False,
+                "already_gone": True,
+            }), 200
+
+        try:
+            result = delete_vault_version(version_key, db_path=DB_PATH)
+        except ValueError as e:
+            # R3 Fix: storage-layer ValueError messages can include absolute
+            # paths (e.g. "Path /opt/x escapes vault root /opt/vault"). Log
+            # the detailed message server-side, but return a generic error
+            # to the client. Matches the wording used for null-byte /
+            # path-traversal rejections above.
+            log.warning("Vault delete '%s' rejected: %s", version_key, e)
+            return jsonify({"error": "Invalid version_key"}), 400
+        except OSError as e:
+            # Fix #3 Option A: filesystem failure should NOT proceed with DB
+            # delete. Storage layer re-raises; we surface as 500 so the row
+            # stays and the client can retry. Match the docstring's promise.
+            #
+            # R3 Fix: PermissionError / FileNotFoundError reprs include the
+            # absolute filesystem path (e.g. [Errno 13] Permission denied:
+            # '/opt/render/project/resume_vault/pdf/X.pdf'). Log it, but
+            # don't leak it to the client.
+            log.error("Vault delete '%s' filesystem error: %s", version_key, e)
+            return jsonify({"error": "Filesystem error while deleting version"}), 500
+
+        # Fix #1: omit absolute filesystem paths from the response. The
+        # booleans pdf_deleted/text_deleted already carry the "did we delete
+        # it" signal, and leaking server paths (e.g. /opt/render/project/...)
+        # exposes internal structure to clients. Surface only the basename of
+        # the PDF for UX (which file was removed), nothing else.
+        pdf_path = result.pop("pdf_path", None)
+        result.pop("text_path", None)
+        result["pdf_filename"] = os.path.basename(pdf_path) if pdf_path else None
+        return jsonify({"status": "deleted", **result}), 200
 
 
 @vault_bp.after_request

--- a/backend/storage/resume_vault.py
+++ b/backend/storage/resume_vault.py
@@ -393,6 +393,126 @@ def list_vault() -> list[dict]:
     return results
 
 
+def _safe_unlink_in_vault(path: str) -> bool:
+    """
+    Delete a file only if its resolved (realpath) location is inside VAULT_DIR.
+
+    Defense against path-traversal: even if `path` was built from user input
+    that included `..` or symlinks, realpath() collapses those — if the result
+    escapes the vault directory, we refuse to unlink.
+
+    Returns True if a file was deleted, False if it did not exist.
+    Raises ValueError if the resolved path is outside the vault.
+    """
+    vault_root = os.path.realpath(VAULT_DIR)
+    target = os.path.realpath(path)
+    if not (target == vault_root or target.startswith(vault_root + os.sep)):
+        raise ValueError(
+            f"Refusing to delete path outside vault: {target!r} not under {vault_root!r}"
+        )
+    if not os.path.exists(target):
+        return False
+    os.remove(target)
+    return True
+
+
+def delete_vault_version(version_key: str, db_path: str = None) -> dict:
+    """
+    Fully delete a resume version: the PDF file, the extracted text file,
+    AND the DB row. Handles partial-state vaults gracefully — a missing file
+    or missing DB row is not an error; we reconcile whatever exists.
+
+    This fixes issue #37: previously the route only removed the DB row, but
+    list_vault() reads the filesystem, so the entry resurrected on refresh.
+
+    Returns:
+        {
+            "version_key": str,
+            "db_row_deleted": bool,
+            "pdf_deleted": bool,
+            "text_deleted": bool,
+            "pdf_path": str | None,   # path attempted (None if no PDF found)
+            "text_path": str,
+        }
+
+    Raises:
+        ValueError if version_key is empty, contains path-traversal sequences,
+        or resolves to a path outside VAULT_DIR.
+        OSError if a vault file exists but cannot be removed. In that case
+        the DB row is NOT deleted — callers should surface the error so the
+        client can retry, rather than orphaning a row whose file is still
+        on disk. (Round 2 Fix #3: code now matches docstring guarantee.)
+    """
+    if not version_key or not isinstance(version_key, str):
+        raise ValueError("version_key is required")
+
+    # Block obvious traversal attempts at the key level before touching disk.
+    # Flask's default <string:> converter already strips '/', but URL-encoded
+    # variants or future routing changes could let them through.
+    if "/" in version_key or "\\" in version_key or ".." in version_key:
+        raise ValueError(f"Invalid version_key: {version_key!r}")
+
+    _ensure_vault()
+
+    if not db_path:
+        db_path = os.environ.get(
+            "DB_PATH", os.path.join(os.path.dirname(__file__), "..", "jobscout.db")
+        )
+
+    pdf_dir = os.path.join(VAULT_DIR, "pdf")
+    text_dir = os.path.join(VAULT_DIR, "text")
+
+    # Locate the PDF whose parsed filename → this version_key.
+    pdf_path = None
+    try:
+        for fname in os.listdir(pdf_dir):
+            if not fname.lower().endswith(".pdf"):
+                continue
+            meta = parse_resume_filename(fname)
+            if meta.get("version_key") == version_key:
+                pdf_path = os.path.join(pdf_dir, fname)
+                break
+    except FileNotFoundError:
+        pdf_path = None
+
+    text_path = os.path.join(text_dir, f"{version_key}.txt")
+
+    # Round 2 Fix #3: propagate OSError so the DB row stays put when an
+    # unlink fails. The previous behaviour (swallow + log warning + still
+    # delete the row) directly contradicted the docstring's "filesystem
+    # failure does not orphan the row" promise — the row was orphaned the
+    # OTHER way: file on disk, row gone, vault permanently un-listable.
+    pdf_deleted = False
+    if pdf_path:
+        pdf_deleted = _safe_unlink_in_vault(pdf_path)
+
+    text_deleted = _safe_unlink_in_vault(text_path)
+
+    # Delete DB row last (so a filesystem failure doesn't orphan the row).
+    from storage.db import get_conn
+    conn = get_conn(db_path)
+    cur = conn.execute(
+        "DELETE FROM resume_versions WHERE version_key = ?", (version_key,)
+    )
+    db_row_deleted = cur.rowcount > 0
+    conn.commit()
+    conn.close()
+
+    log.info(
+        "Vault delete '%s': pdf=%s text=%s db=%s",
+        version_key, pdf_deleted, text_deleted, db_row_deleted,
+    )
+
+    return {
+        "version_key": version_key,
+        "db_row_deleted": db_row_deleted,
+        "pdf_deleted": pdf_deleted,
+        "text_deleted": text_deleted,
+        "pdf_path": pdf_path,
+        "text_path": text_path,
+    }
+
+
 def bulk_import(
     source_dir: str,
     db_path: str = None,

--- a/backend/tests/test_vault_delete.py
+++ b/backend/tests/test_vault_delete.py
@@ -1,0 +1,446 @@
+"""Tests for vault delete endpoint (issue #37) (DELETE /api/vault/version/<key>).
+
+Covers the issue-#37 fix: delete now removes the PDF + text file from the
+filesystem in addition to the DB row, so list_vault() (which scans the disk)
+no longer resurrects the entry on next refresh.
+"""
+import importlib
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    """Flask test client with isolated DB + isolated vault directory."""
+    db_path = str(tmp_path / "test.db")
+    vault_dir = tmp_path / "vault"
+    (vault_dir / "pdf").mkdir(parents=True)
+    (vault_dir / "text").mkdir(parents=True)
+
+    from storage.db import init_db
+    init_db(db_path)
+
+    # Patch vault dir + route DB path
+    import storage.resume_vault as rv_mod
+    monkeypatch.setattr(rv_mod, "VAULT_DIR", str(vault_dir))
+
+    import routes.vault_routes as vr_mod
+    monkeypatch.setattr(vr_mod, "DB_PATH", db_path)
+    # Disable any auth gate if a sibling branch added one (issue-#34).
+    monkeypatch.setattr(vr_mod, "API_SECRET", "", raising=False)
+
+    import server
+    server.DB_PATH = db_path
+    server.app.config["TESTING"] = True
+
+    with server.app.test_client() as c:
+        c._test_db_path = db_path
+        c._test_vault_dir = str(vault_dir)
+        yield c
+
+    importlib.reload(server)
+
+
+def _seed_version(client, version_key="goldman_sachs_data",
+                   display_name="Goldman Sachs",
+                   create_pdf=True, create_text=True, pdf_filename=None):
+    """Create a vault entry: DB row + optionally PDF + text files.
+
+    Picks a PDF filename that round-trips through parse_resume_filename to
+    the supplied version_key — that's how list_vault() links files to keys.
+    """
+    from storage.db import get_conn, upsert_resume_version
+    from storage.resume_vault import parse_resume_filename
+
+    conn = get_conn(client._test_db_path)
+    upsert_resume_version(
+        conn,
+        version_key=version_key,
+        display_name=display_name,
+        resume_text="Python SQL Spark data engineer experience.",
+        skills=["python", "sql", "spark"],
+        target_companies=["Goldman Sachs"],
+    )
+    conn.commit()
+    conn.close()
+
+    pdf_path = None
+    if create_pdf:
+        if pdf_filename is None:
+            pdf_filename = f"Narendranath_{version_key}.pdf"
+            assert parse_resume_filename(pdf_filename)["version_key"] == version_key, (
+                f"Test fixture mismatch: {pdf_filename!r} parses to "
+                f"{parse_resume_filename(pdf_filename)['version_key']!r}, "
+                f"expected {version_key!r}"
+            )
+        pdf_path = os.path.join(client._test_vault_dir, "pdf", pdf_filename)
+        with open(pdf_path, "wb") as f:
+            f.write(b"%PDF-1.4\nfake pdf bytes\n%%EOF\n")
+
+    text_path = None
+    if create_text:
+        text_path = os.path.join(client._test_vault_dir, "text", f"{version_key}.txt")
+        with open(text_path, "w") as f:
+            f.write("Python SQL Spark data engineer experience.")
+
+    return {"pdf_path": pdf_path, "text_path": text_path}
+
+
+# ─────────────────────────────────────────────────────────────────────
+#  Happy path: full delete
+# ─────────────────────────────────────────────────────────────────────
+
+def test_delete_removes_pdf_text_and_db_row(client):
+    paths = _seed_version(client, version_key="goldman_sachs_data")
+    assert os.path.exists(paths["pdf_path"])
+    assert os.path.exists(paths["text_path"])
+
+    resp = client.delete("/api/vault/version/goldman_sachs_data")
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["status"] == "deleted"
+    assert body["version_key"] == "goldman_sachs_data"
+    assert body["pdf_deleted"] is True
+    assert body["text_deleted"] is True
+    assert body["db_row_deleted"] is True
+
+    assert not os.path.exists(paths["pdf_path"])
+    assert not os.path.exists(paths["text_path"])
+
+    from storage.db import get_conn, get_resume_version
+    conn = get_conn(client._test_db_path)
+    assert get_resume_version(conn, "goldman_sachs_data") is None
+    conn.close()
+
+
+def test_delete_then_list_does_not_return_entry(client):
+    """The bug being fixed: after DELETE, GET /list must not include it."""
+    _seed_version(client, version_key="goldman_sachs_data")
+
+    resp = client.get("/api/vault/list")
+    assert resp.status_code == 200
+    pre_keys = [f["version_key"] for f in resp.get_json()["files"]]
+    assert "goldman_sachs_data" in pre_keys
+
+    resp = client.delete("/api/vault/version/goldman_sachs_data")
+    assert resp.status_code == 200
+
+    resp = client.get("/api/vault/list")
+    assert resp.status_code == 200
+    post_keys = [f["version_key"] for f in resp.get_json()["files"]]
+    assert "goldman_sachs_data" not in post_keys
+
+
+# ─────────────────────────────────────────────────────────────────────
+#  Partial-state vault — should NOT 500
+# ─────────────────────────────────────────────────────────────────────
+
+def test_delete_db_row_only_when_pdf_missing(client):
+    """DB row exists but no PDF on disk → 200, DB row gone."""
+    _seed_version(client, version_key="meta_ml", create_pdf=False, create_text=True)
+
+    resp = client.delete("/api/vault/version/meta_ml")
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["status"] == "deleted"
+    assert body["db_row_deleted"] is True
+    assert body["pdf_deleted"] is False
+    assert body["text_deleted"] is True
+
+    from storage.db import get_conn, get_resume_version
+    conn = get_conn(client._test_db_path)
+    assert get_resume_version(conn, "meta_ml") is None
+    conn.close()
+
+
+def test_delete_pdf_only_when_db_row_missing(client):
+    """PDF on disk but no DB row → 200, file gone."""
+    version_key = "goldman_sachs_data"
+    fname = f"Narendranath_{version_key}.pdf"
+    pdf_path = os.path.join(client._test_vault_dir, "pdf", fname)
+    with open(pdf_path, "wb") as f:
+        f.write(b"%PDF-1.4\nfake\n%%EOF\n")
+
+    resp = client.delete(f"/api/vault/version/{version_key}")
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["pdf_deleted"] is True
+    assert body["db_row_deleted"] is False
+    assert not os.path.exists(pdf_path)
+
+
+# ─────────────────────────────────────────────────────────────────────
+#  Response shape (Round 2 Fix #1): no absolute paths leaked
+# ─────────────────────────────────────────────────────────────────────
+
+def test_delete_response_does_not_leak_absolute_paths(client):
+    """Response must not include `pdf_path`/`text_path` (server filesystem
+    structure leak). Only the basename of the deleted PDF is allowed."""
+    paths = _seed_version(client, version_key="goldman_sachs_data")
+    resp = client.delete("/api/vault/version/goldman_sachs_data")
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert "pdf_path" not in body
+    assert "text_path" not in body
+    # Basename ok — it's the filename the user uploaded.
+    assert body.get("pdf_filename") == os.path.basename(paths["pdf_path"])
+    # Sanity: no absolute path snuck into any field.
+    for k, v in body.items():
+        if isinstance(v, str):
+            assert not v.startswith("/"), f"field {k!r} leaks absolute path: {v!r}"
+
+
+# ─────────────────────────────────────────────────────────────────────
+#  Idempotency (Round 2 Fix #5): retried DELETE returns 200 already_gone
+# ─────────────────────────────────────────────────────────────────────
+
+def test_delete_nonexistent_key_returns_200_already_gone(client):
+    """No DB row AND no file on disk → 200 with already_gone:true.
+
+    DELETE's post-condition (resource doesn't exist) is satisfied, so a
+    404 would be hostile to queues/clients that retry on transient errors."""
+    resp = client.delete("/api/vault/version/totally_made_up_key")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["status"] == "deleted"
+    assert body["already_gone"] is True
+    assert body["db_row_deleted"] is False
+    assert body["pdf_deleted"] is False
+    assert body["text_deleted"] is False
+
+
+def test_delete_idempotent_double_call(client):
+    """Two DELETE calls in a row both succeed; second one says already_gone."""
+    _seed_version(client, version_key="goldman_sachs_data")
+
+    first = client.delete("/api/vault/version/goldman_sachs_data")
+    assert first.status_code == 200
+    assert first.get_json().get("already_gone") is not True
+    assert first.get_json()["db_row_deleted"] is True
+
+    second = client.delete("/api/vault/version/goldman_sachs_data")
+    assert second.status_code == 200
+    body = second.get_json()
+    assert body["status"] == "deleted"
+    assert body["already_gone"] is True
+
+
+# ─────────────────────────────────────────────────────────────────────
+#  Path-traversal defense
+# ─────────────────────────────────────────────────────────────────────
+
+def test_delete_path_traversal_url_encoded_slash(client):
+    """`..%2Fetc%2Fpasswd` → decoded to `../etc/passwd`. Flask's default
+    <string:> converter rejects slashes → 404 at routing. File system stays
+    untouched (sentinel outside the vault survives)."""
+    sentinel = os.path.join(client._test_vault_dir, "..", "sentinel.txt")
+    with open(sentinel, "w") as f:
+        f.write("do not delete me")
+
+    resp = client.delete("/api/vault/version/..%2Fetc%2Fpasswd")
+    assert resp.status_code in (400, 404)
+    assert os.path.exists(sentinel)
+
+
+def test_delete_path_traversal_dotdot_in_key(client):
+    """A key with `..` but no slashes passes Flask routing, so the handler
+    must reject it explicitly with 400. The filesystem stays untouched."""
+    sentinel = os.path.join(client._test_vault_dir, "..", "sentinel.txt")
+    with open(sentinel, "w") as f:
+        f.write("do not delete me")
+
+    resp = client.delete("/api/vault/version/..foo")
+    assert resp.status_code == 400
+    assert os.path.exists(sentinel)
+
+
+def test_delete_safe_unlink_refuses_outside_vault(monkeypatch, tmp_path):
+    """Belt-and-suspenders: even if a path somehow resolves outside the
+    vault, _safe_unlink_in_vault refuses with ValueError. Verified by
+    mocking realpath to force an escape result."""
+    import storage.resume_vault as rv_mod
+    vault_dir = str(tmp_path / "vault")
+    os.makedirs(vault_dir, exist_ok=True)
+    monkeypatch.setattr(rv_mod, "VAULT_DIR", vault_dir)
+
+    real_realpath = os.path.realpath
+    outside = "/tmp/escape_target.txt"
+
+    def fake_realpath(p):
+        # The VAULT_DIR call should resolve honestly; everything else escapes.
+        if p == vault_dir:
+            return real_realpath(p)
+        return outside
+
+    monkeypatch.setattr(rv_mod.os.path, "realpath", fake_realpath)
+
+    with pytest.raises(ValueError, match="outside vault"):
+        rv_mod._safe_unlink_in_vault("/anything")
+
+
+# ─────────────────────────────────────────────────────────────────────
+#  Round 2 Fix #4: adversarial key shapes
+# ─────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "raw_key,expected_status,label",
+    [
+        # Absolute path. Flask <string:> rejects the slashes → routing 404
+        # before our handler sees it. Either way, no traversal occurs.
+        ("/etc/passwd", (400, 404), "absolute_path"),
+        # Backslash-only (Windows-style traversal).
+        ("..\\\\etc", (400,), "backslash_only"),
+        # Bare `..` — two dots, no slashes. Passes Flask routing → handler
+        # must explicitly 400 it.
+        ("..", (400,), "bare_dotdot"),
+    ],
+)
+def test_delete_rejects_adversarial_keys(client, raw_key, expected_status, label):
+    """Adversarial keys must be rejected without touching the filesystem.
+
+    Sentinel file lives outside the vault. If any of these keys triggered
+    a delete, the sentinel could vanish. It must survive every case."""
+    sentinel = os.path.join(client._test_vault_dir, "..", f"sentinel_{label}.txt")
+    with open(sentinel, "w") as f:
+        f.write("do not delete me")
+
+    resp = client.delete(f"/api/vault/version/{raw_key}")
+    assert resp.status_code in expected_status, (
+        f"{label}: got {resp.status_code}, expected one of {expected_status}"
+    )
+    assert os.path.exists(sentinel)
+
+
+def test_delete_null_byte_in_key_returns_400(client):
+    """A null byte in the key must NOT propagate to os.path.realpath()
+    (which raises ValueError → 500). Route layer rejects it as 400."""
+    sentinel = os.path.join(client._test_vault_dir, "..", "sentinel_null.txt")
+    with open(sentinel, "w") as f:
+        f.write("do not delete me")
+
+    # Flask's test client URL-decodes; use raw %00 in the URL.
+    resp = client.delete("/api/vault/version/foo%00.pdf")
+    assert resp.status_code == 400, (
+        f"Expected 400 for null-byte key; got {resp.status_code} "
+        f"(body={resp.get_data(as_text=True)})"
+    )
+    assert os.path.exists(sentinel)
+
+
+def test_delete_symlink_target_outside_vault_is_refused(client, tmp_path):
+    """Create a real symlink inside vault/pdf/ pointing OUTSIDE the vault.
+    A delete attempt must refuse — symlink and target both stay intact."""
+    # Real file far away that an attacker would want destroyed.
+    outside_target = tmp_path / "outside_target.txt"
+    outside_target.write_text("precious user data")
+
+    vault_dir = client._test_vault_dir
+    pdf_dir = os.path.join(vault_dir, "pdf")
+    # Use a filename that parses to a clean version_key.
+    symlink_name = "Narendranath_symlink_attack.pdf"
+    symlink_path = os.path.join(pdf_dir, symlink_name)
+
+    try:
+        os.symlink(str(outside_target), symlink_path)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symlinks not supported on this platform")
+
+    from storage.resume_vault import parse_resume_filename
+    version_key = parse_resume_filename(symlink_name)["version_key"]
+
+    # The route should refuse: _safe_unlink_in_vault resolves the symlink's
+    # realpath, sees it's outside the vault, raises ValueError → 400.
+    resp = client.delete(f"/api/vault/version/{version_key}")
+    assert resp.status_code == 400, (
+        f"Expected 400 for symlink-to-outside; got {resp.status_code} "
+        f"(body={resp.get_data(as_text=True)})"
+    )
+
+    # Target file untouched. The symlink itself we don't care about
+    # (it's inside the vault and harmless on its own), but the precious
+    # data it pointed to MUST survive.
+    assert outside_target.exists()
+    assert outside_target.read_text() == "precious user data"
+
+
+# ─────────────────────────────────────────────────────────────────────
+#  Round 3: error responses must NOT leak absolute paths
+# ─────────────────────────────────────────────────────────────────────
+
+def test_delete_valueerror_response_does_not_leak_paths(client, monkeypatch):
+    """If the storage layer raises ValueError with absolute paths in the
+    message (e.g. symlink-escape rejection), the 400 response body must
+    NOT echo those paths back to the client.
+
+    Round 2 introduced a leak at vault_routes.py line 252 where
+    `str(e)` was returned verbatim. Round 3 closes it.
+    """
+    # Seed enough state to get past the idempotency short-circuit.
+    _seed_version(client, version_key="goldman_sachs_data")
+
+    # The route imports delete_vault_version locally, so we patch the
+    # source module's attribute.
+    import storage.resume_vault as rv_mod
+
+    def fake_delete(*args, **kwargs):
+        raise ValueError(
+            "Refusing to delete path outside vault: "
+            "'/opt/secret/whatever' not under '/opt/vault'"
+        )
+
+    monkeypatch.setattr(rv_mod, "delete_vault_version", fake_delete)
+
+    resp = client.delete("/api/vault/version/goldman_sachs_data")
+    assert resp.status_code == 400
+
+    body = resp.get_data(as_text=True)
+    assert "/opt/secret" not in body, f"absolute path leaked: {body!r}"
+    assert "/opt/vault" not in body, f"absolute path leaked: {body!r}"
+    assert "/opt/whatever" not in body, f"absolute path leaked: {body!r}"
+
+    data = resp.get_json()
+    assert data == {"error": "Invalid version_key"}, (
+        f"Expected generic error, got {data!r}"
+    )
+
+
+def test_delete_oserror_response_does_not_leak_paths(client, monkeypatch):
+    """If the storage layer raises OSError/PermissionError (whose repr
+    embeds the absolute path), the 500 response body must NOT echo that
+    path back to the client.
+
+    Round 2's Fix #3 (OSError re-raise) introduced the leak via
+    `f"Filesystem error while deleting: {e}"` at line 258.
+    """
+    _seed_version(client, version_key="goldman_sachs_data")
+
+    # The route imports delete_vault_version locally, so we patch the
+    # source module's attribute.
+    import storage.resume_vault as rv_mod
+
+    def fake_delete(*args, **kwargs):
+        # PermissionError(errno, strerror, filename) — repr() includes the
+        # filename: "[Errno 13] Permission denied: '/opt/secret/path.pdf'"
+        raise PermissionError(13, "Permission denied", "/opt/secret/path.pdf")
+
+    monkeypatch.setattr(rv_mod, "delete_vault_version", fake_delete)
+
+    resp = client.delete("/api/vault/version/goldman_sachs_data")
+    assert resp.status_code == 500
+
+    body = resp.get_data(as_text=True)
+    assert "/opt/secret" not in body, f"absolute path leaked: {body!r}"
+    assert "path.pdf" not in body, f"filename leaked: {body!r}"
+
+    data = resp.get_json()
+    assert data == {"error": "Filesystem error while deleting version"}, (
+        f"Expected generic error, got {data!r}"
+    )

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1520,7 +1520,7 @@ export default function App() {
 
   const deleteVaultVersion = useCallback(async (vk) => {
     if (!RENDER_API) return;
-    if (!window.confirm(`Delete vault version "${vk}"?\n\nNote: this removes the database record only. The PDF file on disk remains; it will reappear next refresh unless removed server-side.`)) return;
+    if (!window.confirm(`Delete vault version "${vk}"? This removes the DB record AND the PDF file from the server.`)) return;
     try {
       const r = await fetch(`${RENDER_API}/api/vault/version/${encodeURIComponent(vk)}`, {method:"DELETE", signal: AbortSignal.timeout(8000)});
       if (!r.ok) {


### PR DESCRIPTION
Closes #37.

## Summary

`DELETE /api/vault/version/<key>` previously removed only the `resume_versions` DB row. `list_vault()` reads from `backend/resume_vault/pdf/` directory, so the row reappeared on the next refresh — making the Delete button a no-op for the primary listing source.

This PR makes delete remove the PDF + text file from disk too, with comprehensive path-traversal defense, idempotent semantics, and no information leakage in error responses.

## What ships

`backend/storage/resume_vault.py`:
- New `delete_vault_version(version_key)` — removes the PDF in `pdf/`, the extracted text in `text/`, and the DB row.
- New `_safe_unlink_in_vault(path)` — `os.path.realpath` assertion against `VAULT_DIR` before `os.unlink`. Refuses any path that escapes the vault root.

`backend/routes/vault_routes.py`:
- DELETE handler rewritten. Path-traversal rejection at route layer (`/`, `\`, `..`, null bytes → 400 with generic message).
- Idempotent semantics: when both PDF and DB row are absent, return **200** with `{"already_gone": true, ...}` so retried DELETEs don't 404.
- OSError now propagates (DB row stays — no orphan-the-other-way).
- Error responses return generic strings; absolute paths stay in server logs only.

`frontend/src/App.jsx`:
- Confirm dialog text updated to reflect the new semantics: `"Delete vault version 'X'? This removes the DB record AND the PDF file from the server."`

## Multi-agent workflow

- **Round 1** (2 parallel implementation agents — Agent A picked on cleaner storage/route split, 8 tests, 106 passing)
- **5 critic lenses**: correctness, tests, security, API contract, code quality
- **Round 1 verdicts**: 5/5 ⚠️ APPROVED-WITH-SUGGESTIONS. Specific findings:
  - Info leakage: `pdf_path`/`text_path` absolute paths returned in 200 body
  - Null byte input caused 500 instead of 400
  - `OSError` swallowed but DB delete proceeded anyway (contradicted docstring)
  - Missing tests for adversarial keys (absolute path, null byte, backslash, bare `..`, symlinks)
  - Idempotency surprise: 404 after successful delete broke client retry logic
  - Sibling endpoint `server.py:675` still has the same bug (filed as #44)
- **Round 2**: applied 5 fixes (omit absolute paths from success response, null-byte → 400, OSError propagates, 5 new parametrized tests including real symlink + monkeypatched realpath escape, 200 with `already_gone:true` for retries)
- **Re-critique by 5 lenses**: 4/5 ✅ APPROVED, 1/5 ⚠️ — security critic found Round 2 introduced a NEW leak: `OSError`/`ValueError` reprs were interpolated into error JSON via `{e}`, leaking absolute paths in 4xx/5xx response bodies
- **Round 3**: removed `{e}` interpolation. Error responses are now generic; details flow to `log.warning` / `log.error` only. Added 2 regression tests proving paths don't leak in `ValueError`/`OSError` paths.
- **Round 3 security re-critique**: ✅ **APPROVED** — **full 5/5 consensus across both rounds**

## Test coverage

`backend/tests/test_vault_routes.py` — 17 tests:
- Happy path: delete removes PDF + text + DB row + entry doesn't reappear on next `/api/vault/list`
- Partial states: DB-only, PDF-only — both succeed with accurate `*_deleted` booleans
- Idempotency: double DELETE returns 200 with `already_gone: true`
- Adversarial (parametrized): `/etc/passwd`, `..\\etc`, bare `..`, URL-encoded slash
- Null byte in key → 400
- Real symlink test: creates `os.symlink` inside vault `pdf/` pointing to a sentinel file outside vault, asserts delete refuses and sentinel survives intact
- Error response leak guards: `ValueError` and `OSError` paths verified NOT to contain absolute paths in body (only in logs)

Suite: **115/115 passed in 42.91s**

## API contract notes

Success response (now path-leak-free):
```json
{
  "status": "deleted",
  "version_key": "gs_data",
  "db_row_deleted": true,
  "pdf_deleted": true,
  "text_deleted": true,
  "pdf_filename": "Narendranath_GS_DE.pdf"
}
```

Idempotent retry:
```json
{
  "status": "deleted",
  "version_key": "gs_data",
  "db_row_deleted": false,
  "pdf_deleted": false,
  "text_deleted": false,
  "already_gone": true
}
```

400 (malformed): `{"error": "Invalid version_key"}`
500 (filesystem): `{"error": "Filesystem error while deleting version"}`
— absolute paths only in server logs, never in HTTP body.

## Out of scope (tracked separately)

- **#44** — the sibling endpoint `/api/resume/versions/<key>` (handled in `server.py:675`) still calls the old `profile_manager.delete_resume_version` which leaves PDFs on disk. Same bug class.

## Test plan

- [x] `cd backend && python -m pytest tests/ -x` — 115 passed
- [x] `cd frontend && npm run build` — clean
- [ ] Manual: upload a PDF to the vault, refresh, delete it via UI → confirm PDF is gone from disk and doesn't reappear
- [ ] Manual: hit DELETE twice via curl → second call should return 200 with `already_gone: true`
- [ ] Manual: try `curl -X DELETE $RENDER/api/vault/version/..%2Fetc%2Fpasswd` → 400 with generic "Invalid version_key"; vault dir unchanged

https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr)_