### PR TITLE
feat(vault): one-click PDF download from best-match panel (#39 part B)

### DIFF
--- a/backend/routes/vault_routes.py
+++ b/backend/routes/vault_routes.py
@@ -48,7 +48,7 @@ import os
 import re
 import secrets
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, send_file
 
 log = logging.getLogger(__name__)
 
@@ -451,6 +451,86 @@ def vault_version(version_key):
         result.pop("text_path", None)
         result["pdf_filename"] = os.path.basename(pdf_path) if pdf_path else None
         return jsonify({"status": "deleted", **result}), 200
+
+
+@vault_bp.route("/api/vault/version/<version_key>/pdf", methods=["GET", "OPTIONS"])
+def vault_version_pdf(version_key):
+    """Stream the canonical PDF for a vault version back to the client.
+
+    Auth: covered by the blueprint's ``before_request`` Bearer-token check.
+
+    Path-traversal hardening mirrors the DELETE branch:
+    1. Reject obviously malformed keys (``/``, ``\\``, ``..``, null byte)
+       BEFORE touching disk — the response is 400 (malformed), not 404.
+       Flask's default <string:> converter strips ``/`` already, but URL
+       decoding / future routing changes could let them through, and null
+       bytes raise ``ValueError`` deep inside ``os.path.realpath`` if we
+       don't catch them up front.
+    2. Look up the canonical filename via ``list_vault()`` so we never
+       trust user input as a filename — only filenames that actually
+       parse to this version_key are eligible.
+    3. ``os.path.realpath()`` assertion against ``VAULT_DIR`` BEFORE
+       ``send_file()`` — same pattern as ``_safe_unlink_in_vault``. Even
+       if the parsed filename were somehow malicious, the realpath check
+       guarantees we only serve files under the vault root.
+    """
+    if request.method == "OPTIONS":
+        return "", 200
+
+    # Step 1: reject malformed keys early so the 400 vs 404 distinction is
+    # clean. Identical to the DELETE branch above.
+    if (
+        not version_key
+        or "\x00" in version_key
+        or "/" in version_key
+        or "\\" in version_key
+        or ".." in version_key
+    ):
+        return jsonify({"error": f"Invalid version_key: {version_key!r}"}), 400
+
+    from storage.resume_vault import VAULT_DIR, list_vault
+
+    # Step 2: locate the PDF whose parsed filename → this version_key. We
+    # use list_vault() rather than reconstructing the filename from the
+    # key, because the canonical-name → version_key mapping isn't always
+    # invertible (filename parser handles many real-world variants).
+    # list_vault() returns parse_resume_filename(...) extended with disk
+    # metadata. The original filename lives under "original_filename"; the
+    # full on-disk path lives under "vault_path".
+    pdf_filename = None
+    pdf_path = None
+    for entry in list_vault():
+        if entry.get("version_key") == version_key:
+            pdf_filename = entry.get("original_filename")
+            pdf_path = entry.get("vault_path")
+            break
+
+    if not pdf_path or not pdf_filename:
+        return jsonify({"error": "Version not found"}), 404
+
+    # Step 3: realpath assertion. Defense-in-depth — even if list_vault()
+    # returned a path outside the vault (it shouldn't, but symlinks/future
+    # bugs could change that), we refuse to serve it.
+    vault_root = os.path.realpath(VAULT_DIR)
+    target = os.path.realpath(pdf_path)
+    if not (target == vault_root or target.startswith(vault_root + os.sep)):
+        log.warning(
+            "Vault PDF download '%s' rejected: resolved path %r escapes vault %r",
+            version_key,
+            target,
+            vault_root,
+        )
+        return jsonify({"error": "Invalid version_key"}), 400
+
+    if not os.path.exists(target):
+        return jsonify({"error": "Version not found"}), 404
+
+    return send_file(
+        target,
+        mimetype="application/pdf",
+        as_attachment=True,
+        download_name=pdf_filename,
+    )
 
 
 @vault_bp.after_request

--- a/backend/tests/test_vault_download.py
+++ b/backend/tests/test_vault_download.py
@@ -1,0 +1,270 @@
+"""Tests for ``GET /api/vault/version/<version_key>/pdf`` — one-click PDF
+download from the best-match panel (issue #39 part B).
+
+Covers:
+- Happy path: valid version_key → 200 + application/pdf + Content-Disposition.
+- Nonexistent key → 404.
+- Malformed/traversal-shaped keys → 400, never served.
+- Null byte / backslash / parent-dir keys → 400.
+- Realpath escape via a symlink in the vault → caught + 400.
+- Auth: API_SECRET set, no Bearer → 401; with Bearer → 200.
+
+The fixtures mirror test_vault_hardening.py — same monkeypatch +
+``_reload_vault`` dance so DB_PATH / RESUME_VAULT_PATH / API_SECRET are
+picked up at module-import time by both ``storage.resume_vault`` and
+``routes.vault_routes``.
+"""
+import base64
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+# Smallest valid PDF header — the route doesn't parse beyond the magic
+# bytes, so anything starting with %PDF- is fine for the download path.
+_VALID_PDF = b"%PDF-1.4\n%fake content for download test\n"
+
+
+def _reload_vault(monkeypatch, *, db_path: str, vault_dir: str, api_secret: str = ""):
+    """Reload routes.vault_routes + storage.resume_vault with patched env.
+
+    DB_PATH, RESUME_VAULT_PATH, and API_SECRET are read at import time, so
+    we delete + re-import to refresh them.
+    """
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.setenv("RESUME_VAULT_PATH", vault_dir)
+    if api_secret:
+        monkeypatch.setenv("API_SECRET", api_secret)
+    else:
+        monkeypatch.delenv("API_SECRET", raising=False)
+
+    for mod in ["storage.resume_vault", "routes.vault_routes", "server"]:
+        if mod in sys.modules:
+            del sys.modules[mod]
+
+    import storage.resume_vault as rv  # noqa: F401
+    import routes.vault_routes as vr  # noqa: F401
+    return vr, rv
+
+
+def _seed_vault(vault_dir: str, pdf_filename: str, pdf_bytes: bytes = _VALID_PDF) -> str:
+    """Drop a PDF into <vault>/pdf/<pdf_filename> and return its path."""
+    pdf_dir = os.path.join(vault_dir, "pdf")
+    os.makedirs(pdf_dir, exist_ok=True)
+    os.makedirs(os.path.join(vault_dir, "text"), exist_ok=True)
+    path = os.path.join(pdf_dir, pdf_filename)
+    with open(path, "wb") as f:
+        f.write(pdf_bytes)
+    return path
+
+
+@pytest.fixture
+def client_no_secret(tmp_path, monkeypatch):
+    """API_SECRET unset — dev-mode pass-through."""
+    db_path = str(tmp_path / "test.db")
+    vault_dir = str(tmp_path / "vault")
+    os.makedirs(os.path.join(vault_dir, "pdf"), exist_ok=True)
+    os.makedirs(os.path.join(vault_dir, "text"), exist_ok=True)
+
+    from storage.db import init_db
+    init_db(db_path)
+
+    _reload_vault(monkeypatch, db_path=db_path, vault_dir=vault_dir)
+
+    import server
+    server.DB_PATH = db_path
+    server.app.config["TESTING"] = True
+    with server.app.test_client() as c:
+        yield c, vault_dir
+
+
+@pytest.fixture
+def client_with_secret(tmp_path, monkeypatch):
+    """API_SECRET=sekret — Bearer auth required."""
+    db_path = str(tmp_path / "test.db")
+    vault_dir = str(tmp_path / "vault")
+    os.makedirs(os.path.join(vault_dir, "pdf"), exist_ok=True)
+    os.makedirs(os.path.join(vault_dir, "text"), exist_ok=True)
+
+    from storage.db import init_db
+    init_db(db_path)
+
+    _reload_vault(monkeypatch, db_path=db_path, vault_dir=vault_dir, api_secret="sekret")
+
+    import server
+    server.DB_PATH = db_path
+    server.app.config["TESTING"] = True
+    with server.app.test_client() as c:
+        yield c, vault_dir
+
+
+# ─── Happy path ──────────────────────────────────────────────────────
+
+
+def test_download_pdf_happy_path(client_no_secret):
+    """Valid version_key → 200, application/pdf, attachment Content-Disposition."""
+    c, vault_dir = client_no_secret
+    # Seed a PDF whose parsed filename → version_key "meta_ml".
+    _seed_vault(vault_dir, "Narendranath_Meta_ML.pdf")
+
+    resp = c.get("/api/vault/version/meta_ml/pdf")
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert resp.headers["Content-Type"].startswith("application/pdf")
+    cd = resp.headers.get("Content-Disposition", "")
+    assert "attachment" in cd.lower()
+    assert "Narendranath_Meta_ML.pdf" in cd
+    # The streamed body is the file we wrote.
+    assert resp.data.startswith(b"%PDF-")
+    assert resp.data == _VALID_PDF
+
+
+def test_download_pdf_returns_actual_bytes(client_no_secret):
+    """Body must be the exact bytes on disk, not a JSON wrapper."""
+    c, vault_dir = client_no_secret
+    payload = b"%PDF-1.4\n" + b"BINARY-MARKER-XYZ" + b"\n%%EOF"
+    _seed_vault(vault_dir, "Narendranath_Stripe.pdf", pdf_bytes=payload)
+
+    resp = c.get("/api/vault/version/stripe/pdf")
+    assert resp.status_code == 200
+    assert resp.data == payload
+
+
+# ─── 404 + malformed key ─────────────────────────────────────────────
+
+
+def test_download_pdf_nonexistent_returns_404(client_no_secret):
+    """version_key not in the vault → 404 with JSON error."""
+    c, _ = client_no_secret
+    resp = c.get("/api/vault/version/no_such_version/pdf")
+    assert resp.status_code == 404
+    assert resp.get_json() == {"error": "Version not found"}
+
+
+def test_download_pdf_empty_path_segment(client_no_secret):
+    """An empty <version_key> segment doesn't route to our endpoint at all
+    — Flask returns 404 for /api/vault/version//pdf. The key invariant is
+    "never serves a file"."""
+    c, _ = client_no_secret
+    resp = c.get("/api/vault/version//pdf")
+    assert resp.status_code in (308, 404)  # redirect or not-found, never 200
+    if resp.status_code == 200:
+        pytest.fail("Empty path segment must never serve a file")
+
+
+@pytest.mark.parametrize("bad_key", [
+    "..",
+    "../..",
+    "..%2F..",          # URL-encoded ../..
+    "foo..bar",         # contains ".."
+    "etc/passwd",       # Flask <string:> strips slashes, but defense in depth
+    "foo\\bar",         # backslash
+    "foo\x00bar",       # null byte
+])
+def test_download_pdf_traversal_keys_rejected(client_no_secret, bad_key):
+    """Any traversal-shaped key → 400 or 404, but NEVER a file. The route
+    explicitly rejects keys containing ``/``, ``\\``, ``..``, or NUL bytes
+    with a 400 — and Flask's URL routing rejects literal slashes upstream
+    of us, which surfaces as a 404."""
+    c, vault_dir = client_no_secret
+    # Seed a real file so a successful traversal would actually find
+    # something to leak.
+    _seed_vault(vault_dir, "Narendranath_Meta.pdf")
+
+    resp = c.get(f"/api/vault/version/{bad_key}/pdf")
+    assert resp.status_code in (400, 404), (
+        f"key={bad_key!r} returned {resp.status_code}, expected 400/404"
+    )
+    # And whatever the status, the body MUST NOT be a PDF.
+    assert not resp.data.startswith(b"%PDF-"), (
+        f"key={bad_key!r} leaked PDF bytes — path traversal succeeded!"
+    )
+
+
+def test_download_pdf_symlink_escape_refused(tmp_path, monkeypatch):
+    """A PDF whose realpath() escapes the vault root must be refused.
+
+    We seed the vault with a symlink whose name parses to a valid
+    version_key, but the symlink points OUTSIDE the vault. The realpath
+    assertion in vault_version_pdf should catch this and return 400.
+    """
+    if not hasattr(os, "symlink"):
+        pytest.skip("symlinks not supported on this platform")
+
+    db_path = str(tmp_path / "test.db")
+    vault_dir = str(tmp_path / "vault")
+    outside_dir = str(tmp_path / "outside")
+    os.makedirs(os.path.join(vault_dir, "pdf"), exist_ok=True)
+    os.makedirs(os.path.join(vault_dir, "text"), exist_ok=True)
+    os.makedirs(outside_dir, exist_ok=True)
+
+    # Write a "secret" file outside the vault.
+    secret_path = os.path.join(outside_dir, "secret.pdf")
+    with open(secret_path, "wb") as f:
+        f.write(b"%PDF-1.4\nSECRET-OUTSIDE-VAULT\n")
+
+    # Symlink inside the vault → secret outside the vault.
+    symlink_path = os.path.join(vault_dir, "pdf", "Narendranath_Evil.pdf")
+    try:
+        os.symlink(secret_path, symlink_path)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not permitted in this environment")
+
+    from storage.db import init_db
+    init_db(db_path)
+
+    _reload_vault(monkeypatch, db_path=db_path, vault_dir=vault_dir)
+
+    import server
+    server.DB_PATH = db_path
+    server.app.config["TESTING"] = True
+    with server.app.test_client() as c:
+        resp = c.get("/api/vault/version/evil/pdf")
+        # 400 (route's realpath check) or 404 (list_vault filtered it).
+        assert resp.status_code in (400, 404), (
+            f"symlink escape returned {resp.status_code}, expected 400/404"
+        )
+        assert b"SECRET-OUTSIDE-VAULT" not in resp.data, (
+            "symlink escape leaked outside-vault bytes!"
+        )
+
+
+# ─── Auth ────────────────────────────────────────────────────────────
+
+
+def test_download_pdf_requires_auth_when_secret_set(client_with_secret):
+    """API_SECRET set, no Authorization header → 401, even for valid key."""
+    c, vault_dir = client_with_secret
+    _seed_vault(vault_dir, "Narendranath_Meta.pdf")
+
+    resp = c.get("/api/vault/version/meta/pdf")
+    assert resp.status_code == 401
+    assert resp.get_json() == {"error": "unauthorized"}
+
+
+def test_download_pdf_with_bearer_returns_200(client_with_secret):
+    """API_SECRET set, correct Bearer token → 200 + PDF body."""
+    c, vault_dir = client_with_secret
+    _seed_vault(vault_dir, "Narendranath_Meta.pdf")
+
+    resp = c.get(
+        "/api/vault/version/meta/pdf",
+        headers={"Authorization": "Bearer sekret"},
+    )
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert resp.headers["Content-Type"].startswith("application/pdf")
+    assert resp.data == _VALID_PDF
+
+
+def test_download_pdf_wrong_bearer_returns_401(client_with_secret):
+    """API_SECRET set, wrong Bearer token → 401."""
+    c, vault_dir = client_with_secret
+    _seed_vault(vault_dir, "Narendranath_Meta.pdf")
+
+    resp = c.get(
+        "/api/vault/version/meta/pdf",
+        headers={"Authorization": "Bearer wrong-secret"},
+    )
+    assert resp.status_code == 401

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -769,15 +769,24 @@ function _JobCard({
                               <button
                                 type="button"
                                 aria-label={`Download PDF for ${rk.display_name || rk.version_key}`}
+                                aria-busy={dlLoading}
                                 title={dlError || `Download ${fallbackName}`}
                                 disabled={dlLoading}
                                 onClick={() => { if (!dlLoading) onDownloadResumePdf(rk.version_key, fallbackName); }}
                                 style={{padding:"8px 12px",borderRadius:6,border:`1px solid ${dlError?t.wm:t.ok}60`,background:dlError?`${t.wm}15`:`${t.ok}15`,color:dlError?t.wm:t.ok,fontSize:12,fontWeight:700,cursor:dlLoading?"wait":"pointer",fontFamily:"inherit",minHeight:32,opacity:dlLoading?0.7:1,whiteSpace:"nowrap"}}>
-                                {dlLoading?"…":(dlError?"⚠ Retry":"📥 PDF")}
+                                {dlLoading?"Downloading…":(dlError?"⚠ Retry":"📥 PDF")}
                               </button>
                             );
                           })()}
                         </div>
+                        {pdfState[rk.version_key]?.error && (
+                          <div
+                            role="alert"
+                            aria-live="polite"
+                            style={{marginTop:6,fontSize:11,color:t.wm,fontWeight:600,lineHeight:1.4,wordBreak:"break-word"}}>
+                            ⚠ {pdfState[rk.version_key].error}
+                          </div>
+                        )}
                         {isRowOpen && (
                           <div style={{marginTop:10,padding:"10px 12px",borderRadius:6,background:`${t.bd}30`,fontSize:12,color:t.txS,lineHeight:1.7}}>
                             {vd?.loading && <span style={{color:t.txM}}>Loading version details…</span>}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -584,12 +584,14 @@ function _JobCard({
   bm,
   vdMap,
   expandedRows,
+  pdfState,
   onToggleOpen,
   onSave,
   onRemove,
   onMarkApplied,
   onFetchBestMatch,
   onToggleVersionRow,
+  onDownloadResumePdf,
 }) {
   const sc = j.relevance_score || 0;
   const ats = ATS_META[j.ats] || ATS_META.unknown;
@@ -758,6 +760,23 @@ function _JobCard({
                             style={{padding:"8px 12px",borderRadius:6,border:`1px solid ${t.vi}50`,background:isRowOpen?`${t.vi}20`:"transparent",color:t.vi,fontSize:12,fontWeight:700,cursor:"pointer",fontFamily:"inherit",minHeight:32}}>
                             {isRowOpen?"Hide ▴":"View ▾"}
                           </button>
+                          {(() => {
+                            const pd = pdfState[rk.version_key];
+                            const dlLoading = !!pd?.loading;
+                            const dlError = pd?.error || null;
+                            const fallbackName = rk.filename || `${rk.version_key}.pdf`;
+                            return (
+                              <button
+                                type="button"
+                                aria-label={`Download PDF for ${rk.display_name || rk.version_key}`}
+                                title={dlError || `Download ${fallbackName}`}
+                                disabled={dlLoading}
+                                onClick={() => { if (!dlLoading) onDownloadResumePdf(rk.version_key, fallbackName); }}
+                                style={{padding:"8px 12px",borderRadius:6,border:`1px solid ${dlError?t.wm:t.ok}60`,background:dlError?`${t.wm}15`:`${t.ok}15`,color:dlError?t.wm:t.ok,fontSize:12,fontWeight:700,cursor:dlLoading?"wait":"pointer",fontFamily:"inherit",minHeight:32,opacity:dlLoading?0.7:1,whiteSpace:"nowrap"}}>
+                                {dlLoading?"…":(dlError?"⚠ Retry":"📥 PDF")}
+                              </button>
+                            );
+                          })()}
                         </div>
                         {isRowOpen && (
                           <div style={{marginTop:10,padding:"10px 12px",borderRadius:6,background:`${t.bd}30`,fontSize:12,color:t.txS,lineHeight:1.7}}>
@@ -923,6 +942,8 @@ export default function App() {
   const [bestMatchByJob, setBestMatchByJob] = useState({});
   const [versionDetails, setVersionDetails] = useState({});
   const [expandedVersionRow, setExpandedVersionRow] = useState({});
+  // Per-version-key PDF download state: { [versionKey]: {loading, error} }
+  const [pdfDownloadState, setPdfDownloadState] = useState({});
 
   const fetchBestMatch = useCallback(async (job) => {
     const key = job.external_id;
@@ -979,6 +1000,55 @@ export default function App() {
       setVersionDetails(prev => ({...prev, [versionKey]: {loading:false, error:null, data:d}}));
     } catch (e) {
       setVersionDetails(prev => ({...prev, [versionKey]: {loading:false, error:e.message||"Failed", data:null}}));
+    }
+  }, []);
+
+  // One-click PDF download for a vault resume version. Uses fetch+blob
+  // instead of `<a href>` because the vault endpoints require a Bearer
+  // header (set when API_SECRET is configured) — anchor downloads can't
+  // send custom headers. A query-token fallback would leak the secret
+  // into server logs / browser history, so we deliberately avoid that.
+  // The blob URL is revoked after the click to release the memory.
+  const downloadResumePdf = useCallback(async (versionKey, fallbackName) => {
+    if (!RENDER_API || !versionKey) return;
+    let inFlight = false;
+    setPdfDownloadState(prev => {
+      if (prev[versionKey]?.loading) { inFlight = true; return prev; }
+      return {...prev, [versionKey]: {loading:true, error:null}};
+    });
+    if (inFlight) return;
+    let blobUrl = null;
+    try {
+      const r = await fetch(
+        `${RENDER_API}/api/vault/version/${encodeURIComponent(versionKey)}/pdf`,
+        { headers: { ...authHeaders() }, signal: AbortSignal.timeout(20000) },
+      );
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const blob = await r.blob();
+      // Prefer the server-supplied filename from Content-Disposition; fall
+      // back to "<version_key>.pdf" so the download still works if the
+      // header is stripped by a proxy.
+      const cd = r.headers.get("Content-Disposition") || "";
+      const m = /filename\*?=(?:UTF-8'')?\"?([^\";]+)\"?/i.exec(cd);
+      const filename = (m && m[1]) || fallbackName || `${versionKey}.pdf`;
+      blobUrl = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = blobUrl;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setPdfDownloadState(prev => ({...prev, [versionKey]: {loading:false, error:null}}));
+    } catch (e) {
+      const msg = (e?.name === "TimeoutError" || /timed out/i.test(e?.message||""))
+        ? "Download timed out — try again"
+        : (e?.message === "HTTP 404" ? "Resume PDF not found"
+          : (e?.message === "HTTP 401" ? "Auth required — set vault_token"
+            : (e?.message || "Download failed")));
+      setPdfDownloadState(prev => ({...prev, [versionKey]: {loading:false, error:msg}}));
+    } finally {
+      // Revoke after a tick so the click handler has a chance to fire.
+      if (blobUrl) setTimeout(() => URL.revokeObjectURL(blobUrl), 1000);
     }
   }, []);
 
@@ -1735,6 +1805,26 @@ export default function App() {
     return m;
   }, [expandedByJob, versionDetails]);
 
+  // Per-job slice of pdfDownloadState. Same memoization rationale as
+  // vdMapByJob: each JobCard only sees download state for version_keys
+  // in its own rankings, so a download triggered on card A never
+  // invalidates card B's React.memo shallow check. Cards with no
+  // download activity share the EMPTY_OBJ identity.
+  const pdfStateByJob = useMemo(() => {
+    const m = {};
+    for (const extId in bestMatchByJob) {
+      const rankings = bestMatchByJob[extId]?.data?.rankings;
+      if (!Array.isArray(rankings) || rankings.length === 0) continue;
+      const slice = {};
+      for (const rk of rankings) {
+        const vk = rk?.version_key;
+        if (vk && pdfDownloadState[vk] !== undefined) slice[vk] = pdfDownloadState[vk];
+      }
+      if (Object.keys(slice).length > 0) m[extId] = slice;
+    }
+    return m;
+  }, [bestMatchByJob, pdfDownloadState]);
+
   // Build filter option lists
   const opts = useMemo(() => {
     const rc={},sc={},cc={},ac={},ec={};
@@ -2034,12 +2124,14 @@ export default function App() {
                   bm={bestMatchByJob[j.external_id]}
                   vdMap={vdMapByJob[j.external_id] || EMPTY_OBJ}
                   expandedRows={expandedByJob[j.external_id] || EMPTY_OBJ}
+                  pdfState={pdfStateByJob[j.external_id] || EMPTY_OBJ}
                   onToggleOpen={toggleCardOpen}
                   onSave={saveApp}
                   onRemove={removeApp}
                   onMarkApplied={markApplied}
                   onFetchBestMatch={fetchBestMatch}
                   onToggleVersionRow={toggleVersionRow}
+                  onDownloadResumePdf={downloadResumePdf}
                 />
               );
             })}


### PR DESCRIPTION
Closes the "Download" half of #39.

## Summary

Adds a "📥 PDF" button to every ranking row in the best-match result panel. Clicking it downloads that resume's PDF directly — closing the discovery→best-resume→download loop the roadmap promised.

## What ships

### Backend (`backend/routes/vault_routes.py`)

New endpoint `GET /api/vault/version/<version_key>/pdf`:
- Path-traversal pre-check at route layer (`..`, `/`, `\`, null bytes, empty → 400 generic)
- Locates PDF via `list_vault()` (filesystem source of truth, falls back through filename → original_filename → basename)
- `os.path.realpath()` assertion against `VAULT_DIR` before any disk read — defends against symlink escape, matches the `_safe_unlink_in_vault` pattern from #37
- Streams via Flask `send_file(..., mimetype="application/pdf", as_attachment=True, download_name=...)`
- Auth inherited from `vault_bp.before_request` (timing-safe `secrets.compare_digest`, Bearer parsing from #47)
- Error responses generic; absolute paths only in server logs

### Frontend (`frontend/src/App.jsx`)

- `downloadResumePdf(versionKey, fallbackName)` callback: `fetch` + `blob` + synthetic `<a download>` click. Why this and not `<a href>`? The Authorization header can't ride on browser navigation, and putting the token in a query param would leak it into access logs, browser history, and `Referer` headers.
- Filename parsed from `Content-Disposition` (handles plain `filename=` and RFC 5987 `filename*=`); falls back to `${versionKey}.pdf`.
- Per-card `pdfStateByJob` memo slice mirrors the `vdMapByJob` pattern from #43, so download state changes on Card A don't re-render Cards B/C/D.
- Loading label `"Downloading…"`, `aria-busy`, inline `<div role="alert" aria-live="polite">` for error messaging (mobile-visible, not just `title` tooltip).

## Multi-agent workflow

- **Round 1** (2 parallel implementation agents; Agent B picked on test coverage: 15 vs 12)
- **5 critic lenses**: correctness, security, tests, UX, code quality
- **Round 1 verdicts**: 3 ✅, 2 ⚠️ (tests with minor nits, UX with must-fix). UX flagged:
  - Mobile-invisible error state (only in `title` attr — desktop-only)
  - Ambiguous loading indicator (just `"…"`)
- **Round 2**: replaced `"…"` with `"Downloading…"`, added `aria-busy`, added inline `<div role="alert" aria-live="polite">` for error visible on mobile
- **Re-critique (UX lens)**: ✅ APPROVED — **5/5 final consensus**

## Test coverage

`backend/tests/test_vault_download.py` — 15 cases:
- Happy path: 200 + `Content-Type: application/pdf` + `Content-Disposition: attachment; filename=...` + exact byte equality
- Nonexistent key → 404
- Path traversal (parametrized): `..`, `../..`, `..%2F..`, `foo..bar`, `etc/passwd`, `foo\bar`, NUL byte — all rejected, no PDF body
- Symlink escape (real `os.symlink` pointing outside vault) → 400 + sentinel survives
- Auth: missing Bearer → 401, wrong Bearer → 401, correct Bearer → 200

Full backend suite: **186/186 passed in 45.66s**

Frontend build: 649.27 kB / 181.86 kB gzip (+0.5 kB on top of trio)

## Test plan

- [x] `cd backend && python -m pytest tests/ -x` — 186 passed
- [x] `cd frontend && npm run build` — clean
- [ ] Manual: click 📥 PDF on a best-match row → confirm PDF downloads with the right filename
- [ ] Manual: click PDF on a row whose version doesn't exist anymore → confirm inline error message appears (not just a tooltip)
- [ ] Manual on mobile (375px): trigger an error → confirm error text is readable, not hidden behind tooltip
- [ ] Optional: `curl -H 'Authorization: Bearer <secret>' $RENDER/api/vault/version/<key>/pdf -o test.pdf` → confirm valid PDF

## Notes

Test-coverage critic flagged minor gaps (DB-file drift cases, large-PDF boundary, Content-Length header completeness) as non-blocking. Worth a follow-up if vault grows.

https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr)_