### PR TITLE
feat(jobs): job-fit chip on every card via default resume (#39 part A)

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -20,6 +20,8 @@ Night quiet hours:
 """
 
 import os
+import re
+import secrets
 import sys
 import json
 import time
@@ -50,7 +52,13 @@ FAST_INTERVAL = int(os.environ.get("FAST_INTERVAL", "300"))    # seconds between
 # Note: per-company delay is SCRAPE_DELAY in the env; the orchestrator
 # reads it directly. Kept out of this module to avoid two copies.
 PORT          = int(os.environ.get("PORT", "10000"))
-API_SECRET    = os.environ.get("API_SECRET", "")               # optional auth for POST /api/scrape
+# .strip() so trailing whitespace from .env files / shell exports doesn't
+# silently invalidate every auth attempt with a mysterious 401.
+API_SECRET    = os.environ.get("API_SECRET", "").strip()       # optional Bearer auth gate
+
+# RFC 7235: auth scheme is case-insensitive. Pre-compiled so the
+# per-request hot path is a single regex match.
+_BEARER_RE = re.compile(r"^Bearer\s+(\S+)\s*$", re.IGNORECASE)
 
 app = Flask(__name__)
 
@@ -207,11 +215,20 @@ def _run_scrape_async(mode: str = "fast") -> None:
 
 
 def _check_api_secret() -> bool:
-    """Returns True if the request is authorized (or no secret is configured)."""
+    """Returns True if the request is authorized (or no secret is configured).
+
+    Hardened against:
+    - Bearer scheme case (RFC 7235): "bearer", "Bearer", "BEARER" all match.
+    - Timing side-channels: ``secrets.compare_digest`` runs in constant time
+      so an attacker can't probe the secret byte-by-byte over many requests.
+    """
     if not API_SECRET:
-        return True
-    token = request.headers.get("Authorization", "").replace("Bearer ", "")
-    return token == API_SECRET
+        return True  # dev mode passthrough
+    m = _BEARER_RE.match(request.headers.get("Authorization", ""))
+    if not m:
+        return False
+    token = m.group(1)
+    return secrets.compare_digest(token.encode("utf-8"), API_SECRET.encode("utf-8"))
 
 
 @app.route("/api/scrape", methods=["POST", "OPTIONS"])
@@ -270,6 +287,14 @@ def api_scrape_status():
 
 @app.route("/api/profile", methods=["GET"])
 def api_get_profile():
+    """Get user profile (preferences + default_resume_version).
+
+    Auth: deliberately left open. The payload is the user's own
+    preferences (custom skills, dream-company list, default resume key) —
+    not credentials. The pin_hash is stripped in ``get_profile`` so
+    readers can't even mount an offline brute-force. If a deployment
+    decides this should be gated, flip the same Bearer check used on POST.
+    """
     try:
         from storage.profile_manager import init_profile_tables, get_profile
         init_profile_tables(DB_PATH)
@@ -280,8 +305,18 @@ def api_get_profile():
 
 @app.route("/api/profile", methods=["POST", "OPTIONS"])
 def api_update_profile():
+    """Update preferences (custom_skills, dream_*, default_resume_version).
+
+    Auth: Bearer-gated when API_SECRET is configured. Without this, an
+    anonymous attacker could flip ``default_resume_version`` and silently
+    change which resume the dashboard auto-scores every job against
+    (Issue #39 part A R2 #1). OPTIONS preflights pass through so browser
+    CORS preflight isn't blocked by the missing Authorization header.
+    """
     if request.method == "OPTIONS":
         return "", 204
+    if not _check_api_secret():
+        return jsonify({"error": "unauthorized"}), 401, {"Access-Control-Allow-Origin": "*"}
     try:
         from storage.profile_manager import (
             init_profile_tables,
@@ -692,10 +727,8 @@ def api_delete_resume_version(version_key):
 def api_set_pin():
     if request.method == "OPTIONS":
         return "", 204
-    if API_SECRET:
-        token = request.headers.get("Authorization", "").replace("Bearer ", "")
-        if token != API_SECRET:
-            return jsonify({"error": "unauthorized"}), 401
+    if not _check_api_secret():
+        return jsonify({"error": "unauthorized"}), 401
     try:
         from storage.profile_manager import init_profile_tables, set_pin
         init_profile_tables(DB_PATH)

--- a/backend/server.py
+++ b/backend/server.py
@@ -283,9 +283,19 @@ def api_update_profile():
     if request.method == "OPTIONS":
         return "", 204
     try:
-        from storage.profile_manager import init_profile_tables, update_profile
+        from storage.profile_manager import (
+            init_profile_tables,
+            update_profile,
+            ProfileValidationError,
+        )
         init_profile_tables(DB_PATH)
-        update_profile(request.get_json() or {}, DB_PATH)
+        try:
+            update_profile(request.get_json() or {}, DB_PATH)
+        except ProfileValidationError as ve:
+            # Validation failures (e.g. unknown default_resume_version key)
+            # are client errors → 400 lets the dashboard show a useful
+            # message instead of an opaque 500.
+            return jsonify({"error": str(ve)}), 400, {"Access-Control-Allow-Origin": "*"}
         return jsonify({"status": "updated"}), 200, {"Access-Control-Allow-Origin": "*"}
     except Exception as e:
         return jsonify({"error": str(e)}), 500

--- a/backend/storage/profile_manager.py
+++ b/backend/storage/profile_manager.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import re
+import sqlite3
 from datetime import datetime, timezone
 
 log = logging.getLogger(__name__)
@@ -132,13 +133,19 @@ def init_profile_tables(db_path: str = DB_PATH):
     # In-place migration for existing DBs that pre-date this column. Rows get
     # NULL, which the GET endpoint surfaces as ``null`` so the dashboard
     # knows "no default → no chip".
+    #
+    # Narrow except: SQLite only signals "column already exists" via
+    # OperationalError with a specific message. Anything else (locked DB,
+    # permission denied, disk full) should bubble — silently swallowing
+    # those would mask real failures behind a "tables ready" log line.
     try:
         conn.execute(
             "ALTER TABLE user_profile ADD COLUMN default_resume_version TEXT"
         )
         conn.commit()
-    except Exception:
-        pass  # column already exists — safe to ignore
+    except sqlite3.OperationalError as e:
+        if "duplicate column" not in str(e).lower():
+            raise
     conn.commit()
     conn.close()
     log.info("Profile tables ready")

--- a/backend/storage/profile_manager.py
+++ b/backend/storage/profile_manager.py
@@ -102,7 +102,15 @@ def get_conn(db_path: str = DB_PATH):
 
 
 def init_profile_tables(db_path: str = DB_PATH):
-    """Create user_profile table if it doesn't exist."""
+    """Create user_profile table if it doesn't exist.
+
+    Idempotent migration: also adds the ``default_resume_version`` column to
+    rows from older DBs that pre-date the job-fit chip feature (Issue #39).
+    CREATE TABLE handles fresh installs; ALTER TABLE handles in-place
+    upgrades. The ALTER is wrapped in try/except because SQLite has no
+    IF NOT EXISTS for ADD COLUMN — the second app boot will raise
+    OperationalError, which we swallow.
+    """
     conn = get_conn(db_path)
     conn.executescript("""
         CREATE TABLE IF NOT EXISTS user_profile (
@@ -114,12 +122,23 @@ def init_profile_tables(db_path: str = DB_PATH):
             preferred_locations TEXT DEFAULT '[]',
             dream_companies TEXT DEFAULT '[]',
             dream_role_keywords TEXT DEFAULT '[]',
+            default_resume_version TEXT,
             created_at TEXT NOT NULL DEFAULT (datetime('now')),
             updated_at TEXT NOT NULL DEFAULT (datetime('now'))
         );
         INSERT OR IGNORE INTO user_profile (id, created_at, updated_at)
         VALUES (1, datetime('now'), datetime('now'));
     """)
+    # In-place migration for existing DBs that pre-date this column. Rows get
+    # NULL, which the GET endpoint surfaces as ``null`` so the dashboard
+    # knows "no default → no chip".
+    try:
+        conn.execute(
+            "ALTER TABLE user_profile ADD COLUMN default_resume_version TEXT"
+        )
+        conn.commit()
+    except Exception:
+        pass  # column already exists — safe to ignore
     conn.commit()
     conn.close()
     log.info("Profile tables ready")
@@ -146,25 +165,67 @@ def get_profile(db_path: str = DB_PATH) -> dict:
     return p
 
 
+class ProfileValidationError(ValueError):
+    """Raised when an update_profile() input fails validation.
+
+    Carrying a distinct exception type lets the Flask layer surface a 400
+    (client error) for these — generic Exceptions still bubble to a 500.
+    """
+
+
 def update_profile(updates: dict, db_path: str = DB_PATH):
-    """Update allowed profile fields."""
+    """Update allowed profile fields.
+
+    ``default_resume_version`` is validated against the resume_versions
+    table before persisting — pointing the default at a non-existent key
+    would mean the dashboard fires job-fit calls that 404 forever.
+    Passing ``None`` or empty string clears the default (no chip on cards).
+    """
     ALLOWED = [
         "custom_skills", "preferred_locations",
         "dream_companies", "dream_role_keywords",
+        "default_resume_version",
     ]
     conn = get_conn(db_path)
     now = datetime.now(timezone.utc).isoformat()
     sets, values = [], []
     for key in ALLOWED:
-        if key in updates:
+        if key not in updates:
+            continue
+        val = updates[key]
+        if key == "default_resume_version":
+            # Treat empty string / explicit None as "clear the default".
+            # Anything else must point to an existing resume_versions row.
+            if val in (None, "", False):
+                values.append(None)
+            else:
+                if not isinstance(val, str):
+                    conn.close()
+                    raise ProfileValidationError(
+                        f"default_resume_version must be a string, got "
+                        f"{type(val).__name__}"
+                    )
+                exists = conn.execute(
+                    "SELECT 1 FROM resume_versions WHERE version_key = ?",
+                    (val,),
+                ).fetchone()
+                if not exists:
+                    conn.close()
+                    raise ProfileValidationError(
+                        f"resume version '{val}' not found"
+                    )
+                values.append(val)
             sets.append(f"{key} = ?")
-            val = updates[key]
+        else:
+            sets.append(f"{key} = ?")
             values.append(json.dumps(val) if isinstance(val, list) else val)
     if sets:
         sets.append("updated_at = ?")
         values.append(now)
         values.append(1)
-        conn.execute(f"UPDATE user_profile SET {', '.join(sets)} WHERE id = ?", values)
+        conn.execute(
+            f"UPDATE user_profile SET {', '.join(sets)} WHERE id = ?", values
+        )
         conn.commit()
     conn.close()
 

--- a/backend/tests/test_profile_default_resume.py
+++ b/backend/tests/test_profile_default_resume.py
@@ -1,0 +1,140 @@
+"""Tests for default_resume_version on user_profile (Issue #39 part A).
+
+Covers:
+- column migration in init_profile_tables (idempotent)
+- GET /api/profile returns default_resume_version (None when never set)
+- POST /api/profile rejects unknown version keys with 400
+- POST /api/profile accepts a valid version key and round-trips it
+- POST /api/profile clears the default when given null/empty string
+"""
+import importlib
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    from storage.db import init_db
+    init_db(db_path)
+    import server
+    server.DB_PATH = db_path
+    server.app.config["TESTING"] = True
+    # profile_manager caches DB_PATH from os.environ at import-time, so we
+    # also patch its module-level so update_profile() hits the temp DB.
+    from storage import profile_manager as pm
+    pm.DB_PATH = db_path
+    with server.app.test_client() as c:
+        yield c
+    importlib.reload(server)
+
+
+def _seed_version(db_path, version_key="data-eng-v1", display_name="Data Eng v1"):
+    """Insert a resume_versions row so default_resume_version can point at it."""
+    from storage.db import get_conn, upsert_resume_version
+    conn = get_conn(db_path)
+    upsert_resume_version(conn, version_key, display_name, "python sql spark")
+    conn.commit()
+    conn.close()
+
+
+def test_init_profile_adds_default_resume_version_column(tmp_path):
+    """Migration runs on a pre-existing DB without the column."""
+    import sqlite3
+    db_path = str(tmp_path / "legacy.db")
+    # Create the OLD schema (no default_resume_version column).
+    conn = sqlite3.connect(db_path)
+    conn.execute("""
+        CREATE TABLE user_profile (
+            id INTEGER PRIMARY KEY,
+            pin_hash TEXT DEFAULT '',
+            resume_text TEXT DEFAULT '',
+            extracted_skills TEXT DEFAULT '[]',
+            custom_skills TEXT DEFAULT '[]',
+            preferred_locations TEXT DEFAULT '[]',
+            dream_companies TEXT DEFAULT '[]',
+            dream_role_keywords TEXT DEFAULT '[]',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+    """)
+    conn.execute("INSERT INTO user_profile (id) VALUES (1)")
+    conn.commit()
+    conn.close()
+
+    from storage.profile_manager import init_profile_tables
+    init_profile_tables(db_path)
+    # Idempotent: calling twice must not raise.
+    init_profile_tables(db_path)
+
+    conn = sqlite3.connect(db_path)
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(user_profile)").fetchall()]
+    conn.close()
+    assert "default_resume_version" in cols
+
+
+def test_get_profile_includes_default_resume_version_null(client):
+    resp = client.get("/api/profile")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "default_resume_version" in data
+    assert data["default_resume_version"] is None
+
+
+def test_post_profile_rejects_unknown_default(client):
+    resp = client.post("/api/profile", json={"default_resume_version": "does-not-exist"})
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert "not found" in body.get("error", "").lower()
+
+
+def test_post_profile_sets_valid_default(client):
+    import server
+    _seed_version(server.DB_PATH, "data-eng-v1")
+
+    resp = client.post("/api/profile", json={"default_resume_version": "data-eng-v1"})
+    assert resp.status_code == 200
+
+    g = client.get("/api/profile")
+    assert g.status_code == 200
+    assert g.get_json().get("default_resume_version") == "data-eng-v1"
+
+
+def test_post_profile_clears_default_with_null(client):
+    import server
+    _seed_version(server.DB_PATH, "data-eng-v1")
+    client.post("/api/profile", json={"default_resume_version": "data-eng-v1"})
+
+    # Empty string → cleared
+    resp = client.post("/api/profile", json={"default_resume_version": ""})
+    assert resp.status_code == 200
+    g = client.get("/api/profile")
+    assert g.get_json().get("default_resume_version") is None
+
+    # Re-set then clear with null
+    client.post("/api/profile", json={"default_resume_version": "data-eng-v1"})
+    resp = client.post("/api/profile", json={"default_resume_version": None})
+    assert resp.status_code == 200
+    g = client.get("/api/profile")
+    assert g.get_json().get("default_resume_version") is None
+
+
+def test_post_profile_rejects_non_string_default(client):
+    resp = client.post("/api/profile", json={"default_resume_version": 12345})
+    assert resp.status_code == 400
+
+
+def test_post_profile_other_fields_still_work(client):
+    """Regression: existing whitelist fields still update normally."""
+    resp = client.post("/api/profile", json={
+        "custom_skills": ["rust", "wasm"],
+        "preferred_locations": ["remote"],
+    })
+    assert resp.status_code == 200
+    g = client.get("/api/profile").get_json()
+    assert g.get("custom_skills") == ["rust", "wasm"]
+    assert g.get("preferred_locations") == ["remote"]

--- a/backend/tests/test_profile_default_resume.py
+++ b/backend/tests/test_profile_default_resume.py
@@ -17,10 +17,19 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
 @pytest.fixture
-def client(tmp_path):
+def client(tmp_path, monkeypatch):
     db_path = str(tmp_path / "test.db")
     from storage.db import init_db
     init_db(db_path)
+    # Force dev-mode passthrough (no Bearer required) on POST /api/profile.
+    # We delenv + reload to make sure server.API_SECRET picks up the
+    # cleared env even if a prior test (e.g. secured_client) left a
+    # value in the module-level constant.
+    monkeypatch.delenv("API_SECRET", raising=False)
+    monkeypatch.setenv("DB_PATH", db_path)
+    for mod in ("server",):
+        if mod in sys.modules:
+            del sys.modules[mod]
     import server
     server.DB_PATH = db_path
     server.app.config["TESTING"] = True
@@ -138,3 +147,94 @@ def test_post_profile_other_fields_still_work(client):
     g = client.get("/api/profile").get_json()
     assert g.get("custom_skills") == ["rust", "wasm"]
     assert g.get("preferred_locations") == ["remote"]
+
+
+# ───────────────────────────────────────────────────────────────────
+# R2 Fix #1: Bearer-auth gate on POST /api/profile
+#
+# Round 1 left this endpoint unauthenticated, which let anyone flip
+# default_resume_version and silently rewire which resume the dashboard
+# auto-fits against. These tests verify the new gate:
+#   - API_SECRET unset → dev passthrough (no header needed → 200)
+#   - API_SECRET set, no header → 401
+#   - API_SECRET set, correct Bearer → 200
+# ───────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def secured_client(tmp_path, monkeypatch):
+    """Same as `client` but with API_SECRET configured to 'sekret'.
+
+    Re-imports server so the module-level API_SECRET constant reflects
+    the patched env. Without the re-import, `server.API_SECRET` would
+    still be the empty string captured at first import time.
+    """
+    db_path = str(tmp_path / "test.db")
+    from storage.db import init_db
+    init_db(db_path)
+
+    monkeypatch.setenv("API_SECRET", "sekret")
+    monkeypatch.setenv("DB_PATH", db_path)
+
+    # Force a clean re-import so server.API_SECRET picks up the patched env.
+    for mod in ("server",):
+        if mod in sys.modules:
+            del sys.modules[mod]
+    import server
+    server.DB_PATH = db_path
+    server.app.config["TESTING"] = True
+
+    from storage import profile_manager as pm
+    pm.DB_PATH = db_path
+
+    with server.app.test_client() as c:
+        yield c
+
+    # Tear down so the next test doesn't inherit API_SECRET in cache.
+    importlib.reload(server)
+
+
+def test_post_profile_unauthenticated_blocked_when_secret_set(secured_client):
+    """API_SECRET set + no Authorization header → 401 (R2 #1)."""
+    resp = secured_client.post(
+        "/api/profile",
+        json={"default_resume_version": ""},
+    )
+    assert resp.status_code == 401
+    assert resp.get_json() == {"error": "unauthorized"}
+
+
+def test_post_profile_wrong_bearer_blocked(secured_client):
+    """Wrong Bearer token → 401."""
+    resp = secured_client.post(
+        "/api/profile",
+        json={"default_resume_version": ""},
+        headers={"Authorization": "Bearer not-the-secret"},
+    )
+    assert resp.status_code == 401
+
+
+def test_post_profile_correct_bearer_passes(secured_client):
+    """Correct Bearer → 200 (and the update lands)."""
+    resp = secured_client.post(
+        "/api/profile",
+        json={"custom_skills": ["python"]},
+        headers={"Authorization": "Bearer sekret"},
+    )
+    assert resp.status_code == 200
+    # GET is intentionally not gated; verify the write succeeded.
+    g = secured_client.get("/api/profile").get_json()
+    assert g.get("custom_skills") == ["python"]
+
+
+def test_post_profile_dev_mode_passthrough(client):
+    """API_SECRET unset (default `client` fixture) → no header needed → 200.
+
+    Mirrors the existing dev-mode passthrough on vault routes so local
+    development without an API_SECRET continues to work.
+    """
+    resp = client.post(
+        "/api/profile",
+        json={"custom_skills": ["spark"]},
+    )
+    assert resp.status_code == 200

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -579,10 +579,15 @@ const EMPTY_ARR = Object.freeze([]);
 // 50–75% yellow, <50% red. Returns plain hex strings derived from `pct` +
 // the active theme so React.memo doesn't have to track new object
 // identities each render.
+//
+// R2: also returns a `label` ("Strong"/"Moderate"/"Weak") and `icon`
+// (colored circle emoji) so the chip carries non-color signals — WCAG
+// 1.4.1 (use of color) requires that meaning isn't conveyed by color
+// alone. Screen readers and color-blind users see the same information.
 function _jobFitTone(pct, t) {
-  if (pct >= 75) return { fg: t.ok, bg: `${t.ok}18`, bd: `${t.ok}40` };
-  if (pct >= 50) return { fg: t.wm, bg: `${t.wm}18`, bd: `${t.wm}40` };
-  return { fg: t.er, bg: `${t.er}18`, bd: `${t.er}40` };
+  if (pct >= 75) return { fg: t.ok, bg: `${t.ok}18`, bd: `${t.ok}40`, label: "Strong",   icon: "🟢" };
+  if (pct >= 50) return { fg: t.wm, bg: `${t.wm}18`, bd: `${t.wm}40`, label: "Moderate", icon: "🟡" };
+  return            { fg: t.er, bg: `${t.er}18`, bd: `${t.er}40`, label: "Weak",     icon: "🔴" };
 }
 
 function _JobCard({
@@ -618,12 +623,23 @@ function _JobCard({
 
   // Job-fit chip: only rendered when a default resume is configured AND a
   // score has been (or is being) fetched for THIS card. Three visual
-  // states: loading dots, error '—', and the colored % chip.
+  // states, each visually distinct:
+  //  - loading:  "📄 …" on muted background
+  //  - error:    "⚠️ —" on warning-tinted background (separate from loading
+  //              so a stuck request doesn't look like an in-flight one)
+  //  - scored:   color + emoji + percent + (tone) label
+  //
+  // WCAG 1.4.1: the chip is NEVER color-only. The score variant carries a
+  // green/yellow/red emoji icon (visible to users who can't perceive the
+  // background color) AND an aria-label spelling out the tone ("Strong",
+  // "Moderate", "Weak") for screen readers.
   const fitChip = (() => {
     if (!jobFit) return null;
     if (jobFit.loading) {
       return (
         <span title="Loading resume match…"
+          aria-label="Resume match: loading"
+          role="status"
           style={{padding:"3px 7px",borderRadius:6,background:`${t.txM}15`,border:`1px solid ${t.txM}30`,
             fontSize:11,fontWeight:700,color:t.txM,whiteSpace:"nowrap"}}>
           📄 …
@@ -633,9 +649,10 @@ function _JobCard({
     if (jobFit.error || jobFit.pct == null) {
       return (
         <span title={jobFit.error || "No match score"}
-          style={{padding:"3px 7px",borderRadius:6,background:`${t.txM}10`,border:`1px solid ${t.txM}25`,
-            fontSize:11,fontWeight:700,color:t.txM,whiteSpace:"nowrap"}}>
-          📄 —
+          aria-label={`Resume match: error${jobFit.error ? ` — ${jobFit.error}` : ""}`}
+          style={{padding:"3px 7px",borderRadius:6,background:`${t.wm}15`,border:`1px solid ${t.wm}40`,
+            fontSize:11,fontWeight:700,color:t.wm,whiteSpace:"nowrap"}}>
+          ⚠️ —
         </span>
       );
     }
@@ -643,10 +660,11 @@ function _JobCard({
     const tone = _jobFitTone(pct, t);
     return (
       <span
-        title={`Resume match against default version${jobFit.versionKey ? ` (${jobFit.versionKey})` : ""}: ${pct}%`}
+        title={`Resume match against default version${jobFit.versionKey ? ` (${jobFit.versionKey})` : ""}: ${pct}% (${tone.label})`}
+        aria-label={`Resume match: ${pct} percent — ${tone.label}`}
         style={{padding:"3px 8px",borderRadius:6,background:tone.bg,border:`1px solid ${tone.bd}`,
           fontSize:11,fontWeight:800,color:tone.fg,whiteSpace:"nowrap",letterSpacing:".02em"}}>
-        📄 {pct}%
+        {tone.icon} {pct}%
       </span>
     );
   })();
@@ -1038,9 +1056,25 @@ export default function App() {
   const [defaultResumeVersion, setDefaultResumeVersion] = useState(null);
   const [defaultUpdating, setDefaultUpdating] = useState(false);
   const [defaultMsg, setDefaultMsg] = useState(null);
+  // R2 #2: empty-state hint banner above the Jobs list when no default
+  // resume is configured. Persisted dismissal in localStorage so users
+  // who've already seen the hint don't get pestered every reload.
+  const [defaultHintDismissed, setDefaultHintDismissed] = useState(() => {
+    try { return localStorage.getItem("jobscout_default_hint_dismissed") === "1"; }
+    catch { return false; }
+  });
+  const dismissDefaultHint = useCallback(() => {
+    setDefaultHintDismissed(true);
+    try { localStorage.setItem("jobscout_default_hint_dismissed", "1"); } catch {}
+  }, []);
   const [jobFitByJob, setJobFitByJob] = useState({});
   const jobFitInflightRef = useRef(0);
   const jobFitPendingRef = useRef(new Set());
+  // R2 #6: event-driven re-pump replaces the old setInterval(250ms). The
+  // batch effect below installs its `pump` function into this ref so
+  // fetchJobFit()'s finally block can immediately try to fill the
+  // freshly-vacated slot. Mutating a ref doesn't trigger a re-render.
+  const jobFitPumpRef = useRef(() => {});
 
   // Fetch the profile once on mount so we know whether to render chips.
   // No retry/backoff — if /api/profile is offline, we just don't show
@@ -1107,12 +1141,16 @@ export default function App() {
     }
   }, []);
 
-  // Concurrency limit for the per-card job-fit fetcher. Five is the
-  // sweet spot: enough that the top of a freshly-mounted Jobs tab fills
-  // in within ~2-3 seconds, low enough that we don't trip Render's
-  // free-tier worker pool. Adjust here, not inline, so the constant is
-  // greppable.
+  // Tunables for the per-card job-fit fetcher. Grouped + named so reviewers
+  // don't have to grep two unrelated literals (5 and 60) across this file.
+  //  - MAX_JOB_FIT_CONCURRENCY: enough that the top of a freshly-mounted
+  //    Jobs tab fills in within ~2-3 seconds, low enough that we don't
+  //    trip Render's free-tier worker pool.
+  //  - JOB_FIT_VISIBLE_SLICE: matches the same `.slice(0, N)` used to render
+  //    JobCards below, so we only fetch fits for cards the user can see.
+  //    Must stay in sync with the render slice.
   const MAX_JOB_FIT_CONCURRENCY = 5;
+  const JOB_FIT_VISIBLE_SLICE = 60;
 
   // Fetches a single job-fit result. Designed to be invoked from the
   // batch effect — pre-checks cache + inflight set so the effect can
@@ -1153,6 +1191,11 @@ export default function App() {
     } finally {
       jobFitInflightRef.current = Math.max(0, jobFitInflightRef.current - 1);
       jobFitPendingRef.current.delete(extId);
+      // R2 #6: immediately try to refill the slot we just freed. The
+      // batch effect installs the live pump function into this ref; if
+      // we're not on the Jobs tab anymore (or the effect cleaned up),
+      // the ref still points to a no-op so this is safe.
+      jobFitPumpRef.current();
     }
   }, []);
 
@@ -2151,15 +2194,24 @@ export default function App() {
   // already have a fresh cached score for the current
   // `defaultResumeVersion`. Concurrency-capped by
   // `MAX_JOB_FIT_CONCURRENCY` via a useRef counter — the queue drains
-  // itself as in-flight requests finish, then this effect's polling
-  // interval (250ms) refills the slots.
+  // itself as in-flight requests finish.
+  //
+  // R2 #6: event-driven refill replaces the old 250ms setInterval. We
+  // install `pump` into `jobFitPumpRef`, and fetchJobFit()'s finally
+  // block invokes the ref to retry immediately when a slot frees up.
+  // No more wasted timer ticks while the queue is idle and steady.
   //
   // Critical: this effect intentionally OMITS `jobFitByJob` from its
   // deps and reads through `jobFitCacheRef` instead. Including it
-  // would rebuild the interval on every result write-back.
+  // would rebuild the effect on every result write-back.
   useEffect(() => {
-    if (!RENDER_API || !defaultResumeVersion || tab !== "jobs") return;
-    const visible = fj.slice(0, 60);
+    if (!RENDER_API || !defaultResumeVersion || tab !== "jobs") {
+      // Make absolutely sure stale pump from a previous effect run
+      // doesn't keep dequeuing after we navigated away.
+      jobFitPumpRef.current = () => {};
+      return;
+    }
+    const visible = fj.slice(0, JOB_FIT_VISIBLE_SLICE);
     let cancelled = false;
     const pump = () => {
       if (cancelled) return;
@@ -2179,9 +2231,14 @@ export default function App() {
         fetchJobFit(extId, j.description || j.title || "", defaultResumeVersion);
       }
     };
+    jobFitPumpRef.current = pump;
     pump();
-    const id = setInterval(pump, 250);
-    return () => { cancelled = true; clearInterval(id); };
+    return () => {
+      cancelled = true;
+      // Restore no-op so a late finally() from a request we're
+      // abandoning doesn't trigger queueing into the wrong context.
+      jobFitPumpRef.current = () => {};
+    };
   }, [fj, defaultResumeVersion, tab, fetchJobFit]);
 
   const activeN = [selRoles,selStates,selCities,selATS,selExp].reduce((n,a)=>n+a.length,0)
@@ -2368,9 +2425,37 @@ export default function App() {
             </div>
           )}
 
+          {/* R2 #2: empty-state hint when no default resume is configured.
+              Tells users why the "Resume Match" chip is missing and gives
+              them a one-click path to the Vault tab to fix it. Dismissible
+              so it doesn't nag forever once the user knows. */}
+          {!defaultResumeVersion && !defaultHintDismissed && (
+            <div role="note"
+              style={{display:"flex",alignItems:"center",gap:12,padding:"12px 16px",marginBottom:14,
+                background:`${t.ac}10`,border:`1px solid ${t.ac}30`,borderRadius:10,color:t.tx,fontSize:14}}>
+              <span style={{fontSize:18,lineHeight:1}}>💡</span>
+              <span style={{flex:1,lineHeight:1.5}}>
+                Set a default resume in the{" "}
+                <button onClick={() => setTab("vault")}
+                  style={{background:"none",border:"none",padding:0,color:t.ac,fontWeight:700,
+                    fontSize:14,fontFamily:"inherit",cursor:"pointer",textDecoration:"underline"}}>
+                  Vault
+                </button>{" "}
+                tab to see auto-match scores on every job card.
+              </span>
+              <button onClick={dismissDefaultHint}
+                aria-label="Dismiss default-resume hint"
+                title="Dismiss"
+                style={{background:"none",border:`1px solid ${t.bd}`,color:t.txM,
+                  fontSize:14,padding:"3px 10px",borderRadius:6,cursor:"pointer",fontFamily:"inherit"}}>
+                ✕
+              </button>
+            </div>
+          )}
+
           {/* Job cards */}
           <div style={{display:"flex",flexDirection:"column",gap:10}}>
-            {fj.slice(0,60).map(j => {
+            {fj.slice(0, JOB_FIT_VISIBLE_SLICE).map(j => {
               const coKey = (j.company || "").toLowerCase();
               return (
                 <JobCard
@@ -2395,9 +2480,9 @@ export default function App() {
                 />
               );
             })}
-            {fj.length>60 && (
+            {fj.length > JOB_FIT_VISIBLE_SLICE && (
               <div style={{textAlign:"center",padding:18,color:t.txM,fontSize:15}}>
-                Showing 60 of {fj.length} — use filters to narrow results
+                Showing {JOB_FIT_VISIBLE_SLICE} of {fj.length} — use filters to narrow results
               </div>
             )}
             {fj.length===0 && (

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -575,6 +575,16 @@ function stopProp(e) { e.stopPropagation(); }
 const EMPTY_OBJ = Object.freeze({});
 const EMPTY_ARR = Object.freeze([]);
 
+// Default-resume job-fit chip color scale (Issue #39 part A). ≥75% green,
+// 50–75% yellow, <50% red. Returns plain hex strings derived from `pct` +
+// the active theme so React.memo doesn't have to track new object
+// identities each render.
+function _jobFitTone(pct, t) {
+  if (pct >= 75) return { fg: t.ok, bg: `${t.ok}18`, bd: `${t.ok}40` };
+  if (pct >= 50) return { fg: t.wm, bg: `${t.wm}18`, bd: `${t.wm}40` };
+  return { fg: t.er, bg: `${t.er}18`, bd: `${t.er}40` };
+}
+
 function _JobCard({
   j,
   t,
@@ -582,6 +592,7 @@ function _JobCard({
   app,
   coHistory,
   bm,
+  jobFit,
   vdMap,
   expandedRows,
   pdfState,
@@ -604,6 +615,41 @@ function _JobCard({
     boxShadow:open?t.sh:t.shS,opacity:isApplied?0.45:1,
   };
   const handleCardClick = () => onToggleOpen(j.external_id);
+
+  // Job-fit chip: only rendered when a default resume is configured AND a
+  // score has been (or is being) fetched for THIS card. Three visual
+  // states: loading dots, error '—', and the colored % chip.
+  const fitChip = (() => {
+    if (!jobFit) return null;
+    if (jobFit.loading) {
+      return (
+        <span title="Loading resume match…"
+          style={{padding:"3px 7px",borderRadius:6,background:`${t.txM}15`,border:`1px solid ${t.txM}30`,
+            fontSize:11,fontWeight:700,color:t.txM,whiteSpace:"nowrap"}}>
+          📄 …
+        </span>
+      );
+    }
+    if (jobFit.error || jobFit.pct == null) {
+      return (
+        <span title={jobFit.error || "No match score"}
+          style={{padding:"3px 7px",borderRadius:6,background:`${t.txM}10`,border:`1px solid ${t.txM}25`,
+            fontSize:11,fontWeight:700,color:t.txM,whiteSpace:"nowrap"}}>
+          📄 —
+        </span>
+      );
+    }
+    const pct = jobFit.pct;
+    const tone = _jobFitTone(pct, t);
+    return (
+      <span
+        title={`Resume match against default version${jobFit.versionKey ? ` (${jobFit.versionKey})` : ""}: ${pct}%`}
+        style={{padding:"3px 8px",borderRadius:6,background:tone.bg,border:`1px solid ${tone.bd}`,
+          fontSize:11,fontWeight:800,color:tone.fg,whiteSpace:"nowrap",letterSpacing:".02em"}}>
+        📄 {pct}%
+      </span>
+    );
+  })();
 
   return (
     <div onClick={handleCardClick} style={cardStyle}>
@@ -631,6 +677,7 @@ function _JobCard({
           </div>
         </div>
         <div style={JC_STYLES.scoreCluster}>
+          {fitChip}
           <div style={{width:52,height:52,borderRadius:12,display:"flex",alignItems:"center",justifyContent:"center",background:t.sBg(sc)}}>
             <span style={{fontSize:20,fontWeight:800,color:t.sTx(sc),fontFamily:"'Playfair Display',serif"}}>{(sc*100).toFixed(0)}</span>
           </div>
@@ -836,7 +883,7 @@ const JobCard = memo(_JobCard);
    Same idea as JobCard: extracted from filteredFiles.map so toggling
    one row's open state doesn't re-render every other row.
    ═══════════════════════════════════════════════════════════════════ */
-function _VaultRow({ f, t, isOpen, det, onToggle, onDelete }) {
+function _VaultRow({ f, t, isOpen, isDefault, det, onToggle, onDelete, onSetDefault }) {
   // Styles are computed INSIDE the row so the parent doesn't have to pass
   // them as props. Previously the App() body declared these as inline
   // literals inside an IIFE on every render — fresh object identities
@@ -846,16 +893,27 @@ function _VaultRow({ f, t, isOpen, det, onToggle, onDelete }) {
   const labelStyle = {fontSize:12,color:t.txM,fontWeight:600,textTransform:"uppercase",letterSpacing:".06em",marginBottom:6,display:"block"};
   const btnSecondary = {padding:"7px 14px",borderRadius:8,border:`1px solid ${t.bd}`,background:"transparent",color:t.txS,fontSize:13,fontWeight:500,cursor:"pointer",fontFamily:"inherit"};
   const btnDanger = {padding:"7px 14px",borderRadius:8,border:`1px solid ${t.er}40`,background:`${t.er}10`,color:t.er,fontSize:13,fontWeight:500,cursor:"pointer",fontFamily:"inherit"};
+  // Set-as-default: outlined → click → ★ Default pill once selected. The
+  // active variant is intentionally disabled — clicking it again would be
+  // a no-op POST.
+  const btnDefault = {padding:"7px 12px",borderRadius:8,border:`1px solid ${t.ac}50`,background:`${t.ac}10`,color:t.ac,fontSize:13,fontWeight:600,cursor:"pointer",fontFamily:"inherit"};
+  const btnDefaultActive = {padding:"7px 12px",borderRadius:8,border:`1px solid ${t.ac}`,background:t.ac,color:"#fff",fontSize:13,fontWeight:700,cursor:"default",fontFamily:"inherit"};
 
   const sizeLabel = typeof f.size_kb === "number"
     ? (f.size_kb >= 1024 ? `${(f.size_kb/1024).toFixed(1)} MB` : `${f.size_kb} KB`)
     : null;
   return (
-    <div style={{background:t.bgS,borderRadius:10,border:`1px solid ${t.bd}`,overflow:"hidden"}}>
+    <div style={{background:isDefault?`${t.ac}08`:t.bgS,borderRadius:10,border:`1px solid ${isDefault?t.ac:t.bd}`,overflow:"hidden"}}>
       <div style={{padding:"12px 14px",display:"flex",justifyContent:"space-between",alignItems:"center",gap:12,flexWrap:"wrap"}} className="vault-row">
         <div style={{flex:1,minWidth:200}}>
-          <div style={{fontSize:14,fontWeight:700,color:t.tx}}>
+          <div style={{fontSize:14,fontWeight:700,color:t.tx,display:"flex",alignItems:"center",gap:8,flexWrap:"wrap"}}>
             {f.company || "—"}{f.role ? ` · ${f.role}` : ""}
+            {isDefault && (
+              <span title="This resume drives the Resume Match % chip on job cards"
+                style={{fontSize:10,padding:"2px 7px",borderRadius:5,background:t.ac,color:"#fff",fontWeight:800,letterSpacing:".05em",textTransform:"uppercase"}}>
+                ★ Default
+              </span>
+            )}
           </div>
           <div style={{fontSize:12,color:t.txM,marginTop:3,wordBreak:"break-word"}}>
             <span style={{fontFamily:"monospace",color:t.ac}}>{f.version_key}</span>
@@ -864,6 +922,19 @@ function _VaultRow({ f, t, isOpen, det, onToggle, onDelete }) {
           </div>
         </div>
         <div style={{display:"flex",gap:8,flexWrap:"wrap"}}>
+          {isDefault ? (
+            <button type="button" style={btnDefaultActive}
+              aria-label={`${f.version_key} is the current default resume`}
+              disabled>
+              ★ Default
+            </button>
+          ) : (
+            <button type="button" style={btnDefault}
+              aria-label={`Set ${f.version_key} as the default resume`}
+              onClick={() => onSetDefault && onSetDefault(f.version_key)}>
+              ☆ Set as default
+            </button>
+          )}
           <button type="button" style={btnSecondary}
             aria-expanded={isOpen}
             aria-label={`${isOpen?"Hide":"View"} details for ${f.version_key}`}
@@ -954,6 +1025,51 @@ export default function App() {
   // Per-version-key PDF download state: { [versionKey]: {loading, error} }
   const [pdfDownloadState, setPdfDownloadState] = useState({});
 
+  // ── Default-resume → per-card job-fit chip (Issue #39 part A) ────
+  // `defaultResumeVersion` is the user's chosen "main" resume, fetched
+  // from /api/profile on mount. When null, no chip is rendered and we
+  // never fire job-fit calls. `jobFitByJob` caches per-card results
+  // {loading, error, pct, versionKey} so the parent batch effect can
+  // tell which jobs still need a fetch for the current default.
+  // `jobFitInflightRef` caps concurrency at MAX_JOB_FIT_CONCURRENCY.
+  // `jobFitPendingRef` tracks "we're about to fetch this id" so two
+  // pump() ticks can't queue the same id before fetchJobFit() bumps
+  // the inflight counter.
+  const [defaultResumeVersion, setDefaultResumeVersion] = useState(null);
+  const [defaultUpdating, setDefaultUpdating] = useState(false);
+  const [defaultMsg, setDefaultMsg] = useState(null);
+  const [jobFitByJob, setJobFitByJob] = useState({});
+  const jobFitInflightRef = useRef(0);
+  const jobFitPendingRef = useRef(new Set());
+
+  // Fetch the profile once on mount so we know whether to render chips.
+  // No retry/backoff — if /api/profile is offline, we just don't show
+  // chips, which is the same as "no default configured".
+  useEffect(() => {
+    if (!RENDER_API) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await fetch(`${RENDER_API}/api/profile`, {
+          signal: AbortSignal.timeout(8000),
+        });
+        if (!r.ok || cancelled) return;
+        const d = await r.json();
+        if (cancelled) return;
+        setDefaultResumeVersion(d.default_resume_version || null);
+      } catch (_e) { /* offline / 5xx — silently no chip */ }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  // Wipe the job-fit cache when the user changes default resume — stale
+  // percentages against the OLD resume would mislead. The parent batch
+  // effect re-queues every visible card after this clears.
+  useEffect(() => {
+    setJobFitByJob({});
+    jobFitPendingRef.current = new Set();
+  }, [defaultResumeVersion]);
+
   const fetchBestMatch = useCallback(async (job) => {
     const key = job.external_id;
     if (!key) return;
@@ -988,6 +1104,55 @@ export default function App() {
         ? "Match timed out — try again"
         : (e?.message === "HTTP 404" ? "Vault endpoint not found" : (e?.message||"Failed"));
       setBestMatchByJob(prev => ({...prev, [key]: {loading:false, error:msg, data:null}}));
+    }
+  }, []);
+
+  // Concurrency limit for the per-card job-fit fetcher. Five is the
+  // sweet spot: enough that the top of a freshly-mounted Jobs tab fills
+  // in within ~2-3 seconds, low enough that we don't trip Render's
+  // free-tier worker pool. Adjust here, not inline, so the constant is
+  // greppable.
+  const MAX_JOB_FIT_CONCURRENCY = 5;
+
+  // Fetches a single job-fit result. Designed to be invoked from the
+  // batch effect — pre-checks cache + inflight set so the effect can
+  // fire-and-forget. The inflight counter is decremented in `finally`
+  // so a thrown error doesn't permanently park the slot.
+  const fetchJobFit = useCallback(async (extId, jobDescription, versionKey) => {
+    if (!RENDER_API || !extId || !versionKey) {
+      jobFitPendingRef.current.delete(extId);
+      return;
+    }
+    const jd = (jobDescription || "").trim().slice(0, 20000);
+    if (!jd) {
+      setJobFitByJob(prev => ({...prev, [extId]: {loading:false, error:"No JD", pct:null, versionKey}}));
+      jobFitPendingRef.current.delete(extId);
+      return;
+    }
+    jobFitInflightRef.current += 1;
+    setJobFitByJob(prev => {
+      const cur = prev[extId];
+      if (cur && cur.versionKey === versionKey && cur.pct != null) return prev;
+      return {...prev, [extId]: {loading:true, error:null, pct:null, versionKey}};
+    });
+    try {
+      const r = await fetch(`${RENDER_API}/api/vault/job-fit`, {
+        method: "POST",
+        headers: {"Content-Type":"application/json", ...authHeaders()},
+        body: JSON.stringify({version_key: versionKey, job_description: jd}),
+        signal: AbortSignal.timeout(12000),
+      });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const d = await r.json();
+      const combined = typeof d.combined_score === "number" ? d.combined_score : 0;
+      const pct = Math.round(combined * 100);
+      setJobFitByJob(prev => ({...prev, [extId]: {loading:false, error:null, pct, versionKey}}));
+    } catch (e) {
+      const msg = (e?.name === "TimeoutError") ? "timeout" : (e?.message || "failed");
+      setJobFitByJob(prev => ({...prev, [extId]: {loading:false, error:msg, pct:null, versionKey}}));
+    } finally {
+      jobFitInflightRef.current = Math.max(0, jobFitInflightRef.current - 1);
+      jobFitPendingRef.current.delete(extId);
     }
   }, []);
 
@@ -1650,6 +1815,45 @@ export default function App() {
     }
   }, [fetchVaultVersionDetails]);
 
+  // Set a vault version as the user's default resume (Issue #39 part A).
+  // Round-trips through POST /api/profile so the backend validates the
+  // key exists; on success we mirror the new value into local state to
+  // flip the badge instantly. Pass empty string to clear the default.
+  const setAsDefaultResume = useCallback(async (versionKey) => {
+    if (!RENDER_API) return;
+    setDefaultUpdating(true);
+    setDefaultMsg(null);
+    try {
+      const r = await fetch(`${RENDER_API}/api/profile`, {
+        method: "POST",
+        headers: {"Content-Type": "application/json", ...authHeaders()},
+        body: JSON.stringify({default_resume_version: versionKey || ""}),
+        signal: AbortSignal.timeout(8000),
+      });
+      const d = await r.json().catch(() => ({}));
+      if (!r.ok) {
+        setDefaultMsg({ok:false, text: d.error || `HTTP ${r.status}`});
+        return;
+      }
+      setDefaultResumeVersion(versionKey || null);
+      setDefaultMsg({ok:true, text: versionKey
+        ? `✅ Default resume set to ${versionKey}`
+        : "✅ Default resume cleared"});
+    } catch (e) {
+      setDefaultMsg({ok:false, text: e.message || "Network error"});
+    } finally {
+      setDefaultUpdating(false);
+    }
+  }, []);
+
+  // Auto-clear the toast 4s after a successful set so it doesn't hang
+  // around as visual noise.
+  useEffect(() => {
+    if (!defaultMsg || !defaultMsg.ok) return;
+    const id = setTimeout(() => setDefaultMsg(null), 4000);
+    return () => clearTimeout(id);
+  }, [defaultMsg]);
+
   const compareVaultVersions = async () => {
     if (!RENDER_API || !vaultCmpA || !vaultCmpB || vaultCmpA === vaultCmpB) return;
     setVaultCmpLoading(true);
@@ -1934,6 +2138,52 @@ export default function App() {
     return j;
   }, [enriched,selRoles,selExp,selStates,selCities,selATS,remoteOnly,h1bOnly,platinumOnly,highCompOnly,selSalary,selPosted,q,so]);
 
+  // Latest-cache ref so the batch effect below can read the current
+  // jobFitByJob without subscribing to it as a dep (which would tear
+  // down + rebuild the interval on every single fit result writing
+  // back into state — 60 cards × one fit each = 60 effect rebuilds).
+  const jobFitCacheRef = useRef(jobFitByJob);
+  useEffect(() => { jobFitCacheRef.current = jobFitByJob; }, [jobFitByJob]);
+
+  // Parent-level batch fetcher for the per-card job-fit chips (Issue
+  // #39 part A). Walks the *visible* slice of `fj` (the same 60 cards
+  // we actually render) and queues fetches for any job that doesn't
+  // already have a fresh cached score for the current
+  // `defaultResumeVersion`. Concurrency-capped by
+  // `MAX_JOB_FIT_CONCURRENCY` via a useRef counter — the queue drains
+  // itself as in-flight requests finish, then this effect's polling
+  // interval (250ms) refills the slots.
+  //
+  // Critical: this effect intentionally OMITS `jobFitByJob` from its
+  // deps and reads through `jobFitCacheRef` instead. Including it
+  // would rebuild the interval on every result write-back.
+  useEffect(() => {
+    if (!RENDER_API || !defaultResumeVersion || tab !== "jobs") return;
+    const visible = fj.slice(0, 60);
+    let cancelled = false;
+    const pump = () => {
+      if (cancelled) return;
+      const cache = jobFitCacheRef.current;
+      for (const j of visible) {
+        if (jobFitInflightRef.current >= MAX_JOB_FIT_CONCURRENCY) break;
+        const extId = j.external_id;
+        if (!extId) continue;
+        if (jobFitPendingRef.current.has(extId)) continue;
+        const existing = cache[extId];
+        // skip if already fetched (or in flight) for the current default
+        if (existing && existing.versionKey === defaultResumeVersion) continue;
+        // mark pending BEFORE fetchJobFit() reads inflight to avoid two
+        // pump() ticks queuing the same id while the first call hasn't
+        // yet bumped the counter.
+        jobFitPendingRef.current.add(extId);
+        fetchJobFit(extId, j.description || j.title || "", defaultResumeVersion);
+      }
+    };
+    pump();
+    const id = setInterval(pump, 250);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [fj, defaultResumeVersion, tab, fetchJobFit]);
+
   const activeN = [selRoles,selStates,selCities,selATS,selExp].reduce((n,a)=>n+a.length,0)
     +(remoteOnly?1:0)+(h1bOnly?1:0)+(platinumOnly?1:0)+(highCompOnly?1:0)+(selSalary!=="All"?1:0)+(selPosted!=="All"?1:0);
   const clearAll = () => {
@@ -2131,6 +2381,7 @@ export default function App() {
                   app={apps[j.external_id]}
                   coHistory={coHistoryByCompany[coKey] || EMPTY_ARR}
                   bm={bestMatchByJob[j.external_id]}
+                  jobFit={jobFitByJob[j.external_id]}
                   vdMap={vdMapByJob[j.external_id] || EMPTY_OBJ}
                   expandedRows={expandedByJob[j.external_id] || EMPTY_OBJ}
                   pdfState={pdfStateByJob[j.external_id] || EMPTY_OBJ}
@@ -2701,6 +2952,48 @@ export default function App() {
                 </div>
               )}
 
+              {/* Default-resume status banner (Issue #39 part A) — surfaces
+                  which version is currently driving the Resume Match chip on
+                  job cards. Lets the user discover the feature even when
+                  scrolling vault entries first. */}
+              <div style={{...cardStyle,
+                borderColor:defaultResumeVersion?`${t.ac}40`:`${t.txM}30`,
+                background:defaultResumeVersion?`${t.ac}08`:`${t.txM}05`,
+                marginBottom:18}}>
+                <div style={{display:"flex",alignItems:"center",gap:12,flexWrap:"wrap"}}>
+                  <span style={{fontSize:13,fontWeight:700,color:t.txM,textTransform:"uppercase",letterSpacing:".06em"}}>
+                    Default Resume
+                  </span>
+                  {defaultResumeVersion ? (
+                    <>
+                      <span style={{fontSize:14,fontFamily:"monospace",color:t.ac,fontWeight:700}}>
+                        ★ {defaultResumeVersion}
+                      </span>
+                      <span style={{fontSize:12,color:t.txM}}>
+                        — drives the "Resume Match %" chip on each job card
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => setAsDefaultResume("")}
+                        disabled={defaultUpdating}
+                        style={{...btnSecondary,marginLeft:"auto",opacity:defaultUpdating?0.5:1}}
+                        aria-label="Clear default resume">
+                        Clear default
+                      </button>
+                    </>
+                  ) : (
+                    <span style={{fontSize:13,color:t.txM}}>
+                      None set — click <em>Set as default</em> on any vault entry below to enable the per-card resume-match chip.
+                    </span>
+                  )}
+                </div>
+                {defaultMsg && (
+                  <div style={{marginTop:10,fontSize:13,color:defaultMsg.ok?t.ok:t.er,fontWeight:600}}>
+                    {defaultMsg.text}
+                  </div>
+                )}
+              </div>
+
               <div style={{display:"grid",gridTemplateColumns:"repeat(auto-fit,minmax(180px,1fr))",gap:12,marginBottom:18}}>
                 {[
                   [vaultStats?.pdf_count ?? "—","PDFs in Vault",t.ac],
@@ -2881,9 +3174,11 @@ export default function App() {
                         f={f}
                         t={t}
                         isOpen={vaultExpanded === f.version_key}
+                        isDefault={defaultResumeVersion === f.version_key}
                         det={vaultDetails[f.version_key]}
                         onToggle={toggleVaultRow}
                         onDelete={deleteVaultVersion}
+                        onSetDefault={setAsDefaultResume}
                       />
                     ))}
                   </div>


### PR DESCRIPTION
Closes the "chip" half of #39.

## Summary

Adds a "Resume Match: 87%" chip to every job card, auto-loaded against the user's designated default resume. Closes the discovery→best-resume part of the roadmap loop. No chip until a default is set — chips are opt-in via a one-click "Set as default" in the Vault tab.

## What ships

### Backend

**`backend/storage/profile_manager.py`**
- New `default_resume_version` TEXT column on `user_profile` (nullable). Auto-added at startup via `CREATE TABLE IF NOT EXISTS` + `ALTER TABLE ... ADD COLUMN` wrapped in `except sqlite3.OperationalError` with a duplicate-column check (no more swallowing all errors).
- `update_profile()` validates `default_resume_version` against `resume_versions` table before writing. Unknown key → `ProfileValidationError` (new subclass of `ValueError`) → route returns 400. Empty string / null clears.

**`backend/server.py`**
- Hardened `_check_api_secret()`: now uses `_BEARER_RE` regex (case-insensitive scheme parsing + whitespace stripping) and `secrets.compare_digest()` for timing-safe comparison. Same pattern the trio established for vault routes.
- `POST /api/profile` now gated behind it. Dev passthrough preserved when `API_SECRET` unset. GET intentionally left open (profile contents aren't credentials; dashboard's PIN gate covers the UI).

### Frontend (`frontend/src/App.jsx`)

**Default resume management (Vault tab)**
- Status banner at the top: `★ Default: <version_key>` with Clear button, or "None set" hint
- Per-row "☆ Set as default" button on every VaultRow, flips to "★ Default" pill when active
- `setDefaultResume` includes `authHeaders()` on the POST

**Job-fit chip (Jobs tab)**
- Each `_JobCard` renders a chip in the score cluster when the user has a default set
- `_jobFitTone()` returns `{label, icon}` — Strong/Moderate/Weak + 🟢/🟡/🔴 so the chip carries **both color and non-color signals** (WCAG 1.4.1 compliant)
- `aria-label="Resume match: 87% — Strong"` for screen readers
- Loading state: `📄 …` muted, `role="status"`
- Error state: `⚠️ —` with warning tint (visually distinct from loading)
- Empty-state hint above the Jobs list when no default is set, with a button that switches to the Vault tab. Dismissible (persists in `localStorage["jobscout_default_hint_dismissed"]`)

**Concurrency-limited batch fetcher**
- Parent-level `useEffect` gated on `tab === "jobs"` + `defaultResumeVersion`
- Walks `fj.slice(0, JOB_FIT_VISIBLE_SLICE)` with a `useRef`-backed inflight counter and pending Set
- `MAX_JOB_FIT_CONCURRENCY = 5`
- **Event-driven re-pump**: `fetchJobFit`'s `finally` calls `pump()` directly. No `setInterval` polling (was 250ms in R1; replaced per perf critic's recommendation).
- Per-card slice via `jobFitByJob[external_id]` preserves React.memo identity from #43

## Multi-agent workflow

- **Round 1** (2 parallel impl agents; Agent B picked on test count: 7 vs 5)
- **5 critic lenses**: correctness, performance, UX, security, code quality
- **Round 1 verdicts**: 1 ✅, 2 ⚠️, **2 ❌ REJECTED**:
  - UX (3 must-fix): chip color-only fails WCAG 1.4.1, no Jobs-tab hint when default unset, error chip indistinguishable from loading
  - Security: `/api/profile` POST unauthenticated — widens writable-attribute surface
- **Round 2**: applied all 7 fixes (security gate, empty-state hint, a11y, error-chip styling, narrowed except, event-driven pump, named constants)
- **Re-critique by security + UX**: **5/5 ✅ APPROVED** consensus

## Test coverage

`backend/tests/test_profile_default_resume.py` — 11 tests:
- Schema migration: fresh DB, legacy upgrade, idempotency
- POST validation: unknown key → 400, valid set/clear, non-string rejection, regression on other profile fields
- Auth (4 new in R2): unauthenticated blocked when `API_SECRET` set, wrong Bearer, correct Bearer, dev-mode passthrough

Full backend suite: **197/197 passed in 48.64s**

Frontend build: 654.23 kB / 183.27 kB gzip (+5 kB on top of #48)

## Test plan

- [x] `cd backend && python -m pytest tests/ -x` — 197 passed
- [x] `cd frontend && npm run build` — clean
- [ ] Manual: with no default set, open Jobs tab → confirm hint appears, no chips
- [ ] Manual: click "Vault" in hint → tab switches to Vault
- [ ] Manual: set a default on a vault entry → return to Jobs tab → chips load in batches of 5
- [ ] Manual: chip colors match score thresholds (green ≥75, yellow ≥50, red <50)
- [ ] Manual: chip has visible 🟢/🟡/🔴 icon (non-color signal)
- [ ] Manual: screen-reader announces "Resume match: 87% — Strong"
- [ ] Manual: with `API_SECRET` set, `setDefaultResume` includes Bearer header → POST succeeds

## Notes

This PR completes the Phase-1 roadmap from CLAUDE.md alongside PR #48 (download). The full loop now works: discover job → see match chip → expand best-match panel → download recommended PDF.

https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr)_