### PR TITLE
fix(server): self-describing root endpoint — version 3.1 + auto-discover routes

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -743,11 +743,19 @@ def api_set_pin():
 
 @app.route("/")
 def index():
+    # Auto-discover routes from app.url_map so this list never drifts when
+    # new blueprints are registered. Filter out static/internal Flask
+    # routes and keep the output stable across deploys (sorted).
+    endpoints = sorted({
+        r.rule for r in app.url_map.iter_rules()
+        if not r.rule.startswith("/static")
+        and r.endpoint != "static"
+    })
     return jsonify({
         "service":   "JobScout API",
-        "version":   "3.0",
-        "endpoints": ["/api/data", "/api/health", "/api/stats", "/api/scrape",
-                      "/api/profile", "/api/resume", "/api/verify-pin", "/ping"],
+        "version":   "3.1",
+        "endpoints": endpoints,
+        "endpoint_count": len(endpoints),
         **state.health(),
     }), 200, {"Access-Control-Allow-Origin": "*"}
 


### PR DESCRIPTION
## What this fixes

The `GET /` endpoint was lying about the server. It returned:

```json
{ "version": "3.0",
  "endpoints": ["/api/data", "/api/health", "/api/stats", "/api/scrape",
                "/api/profile", "/api/resume", "/api/verify-pin", "/ping"] }
```

…even though the deploy is on v3.1 and has **34 routes** registered, including all 9 `/api/vault/*` endpoints and the `/api/admin/*` Blueprint.

This is exactly the misleading response that made the live `jobscout-api-lasz.onrender.com` look pre-vault in screenshots earlier today — sending users + Claude on a wild goose chase looking for a "missing" deploy. The vault was always live; the root just never said so.

## Approach

Generate the endpoint list dynamically from `app.url_map` so it can't drift again when a new blueprint registers. Bump the hardcoded version string to match CLAUDE.md.

```python
endpoints = sorted({
    r.rule for r in app.url_map.iter_rules()
    if not r.rule.startswith("/static")
    and r.endpoint != "static"
})
```

Also add `endpoint_count` for at-a-glance health checking.

## Verification

Ran `flask.test_client().get('/')` locally:

| Field | Before | After |
|---|---|---|
| `version` | `"3.0"` | `"3.1"` |
| `endpoint_count` | absent | `34` |
| `/api/vault/*` routes in response | **0** | **9** |
| `/api/admin/*` routes in response | 0 | 5 |
| `/api/applications/*` routes in response | 0 | 5 |

## Test plan

- [x] `flask.test_client().get('/')` returns 200 with version 3.1 and 34 endpoints
- [x] Vault routes appear in the response (`/api/vault/upload`, `.../list`, etc.)
- [x] Existing `state.health()` fields (uptime, total_cycles, etc.) still present via `**state.health()` spread
- [ ] After Render redeploys, visit `https://jobscout-api-lasz.onrender.com/` and confirm version is now 3.1 with all 34 routes
- [ ] Confirm `/ping`, `/api/data`, `/api/health` still respond as before (no regression)

## Notes

- Pure backend change. No frontend impact.
- The `Access-Control-Allow-Origin: *` header is preserved on the response (the existing `add_cors` after_request hook continues to apply since `/` is not in the vault/admin path prefix exclusion list).
- One untracked piece of drift remaining (separate PR): CLAUDE.md says "109 companies" but `companies.py` now has 147 across 4 tiers (0/1/2/3, not 3 tiers). That's documentation cleanup, not a code bug.

https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr)_