### PR TITLE
fix(vault): upload UI cap 5MB → 10MB to match backend MAX_PDF_BYTES

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2076,8 +2076,12 @@ export default function App() {
       setVaultUpStatus({ok:false, msg:"PDF file and company name required"});
       return;
     }
-    if (vaultUpFile.size > 5 * 1024 * 1024) {
-      setVaultUpStatus({ok:false, msg:`❌ File too large (${(vaultUpFile.size/1024/1024).toFixed(1)} MB) — max 5 MB`});
+    // Mirrors MAX_PDF_BYTES in backend/storage/resume_vault.py:337 and
+    // backend/routes/vault_routes.py:69. Frontend was artificially rejecting
+    // 5–10 MB PDFs that the server would have accepted.
+    const MAX_UPLOAD_BYTES = 10_000_000;
+    if (vaultUpFile.size > MAX_UPLOAD_BYTES) {
+      setVaultUpStatus({ok:false, msg:`❌ File too large (${(vaultUpFile.size/1024/1024).toFixed(1)} MB) — max 10 MB`});
       return;
     }
     setVaultUpLoading(true);
@@ -3263,7 +3267,7 @@ export default function App() {
                 <h3 style={{margin:"0 0 16px",fontSize:13,color:t.txM,fontWeight:700,textTransform:"uppercase",letterSpacing:".08em"}}>Upload New Resume</h3>
                 <div style={{display:"grid",gridTemplateColumns:"repeat(auto-fit,minmax(220px,1fr))",gap:12}}>
                   <div>
-                    <label htmlFor="vault-up-file" style={labelStyle}>PDF File <span style={{color:t.txS,fontWeight:400}}>(max 5 MB)</span></label>
+                    <label htmlFor="vault-up-file" style={labelStyle}>PDF File <span style={{color:t.txS,fontWeight:400}}>(max 10 MB)</span></label>
                     <input id="vault-up-file" ref={vaultFileInputRef} type="file" accept="application/pdf,.pdf"
                       onChange={e => setVaultUpFile(e.target.files?.[0] || null)}
                       style={{...iS,padding:"9px 12px"}}/>


### PR DESCRIPTION
## What broke

The vault upload form was artificially refusing PDFs between **5 MB and 10 MB** at the client, even though the backend would have accepted them. Two places hardcoded the 5 MB limit:

- `frontend/src/App.jsx:2079` — `if (vaultUpFile.size > 5 * 1024 * 1024)` rejected the file before the request left the browser
- `frontend/src/App.jsx:3266` — UI label said "max 5 MB"

Meanwhile the backend's source of truth is **10 MB** in three independent locations:
- `backend/storage/resume_vault.py:337` — `MAX_PDF_BYTES = 10_000_000`
- `backend/routes/vault_routes.py:69` — same constant, route-layer guard
- `backend/tests/test_vault_hardening.py:410` — test that exactly 10 MB passes

Net effect: a user trying to upload a 7 MB resume hit "File too large" without ever reaching the server, even though the server (and its tests) would have accepted it.

## Fix

Two-spot change in App.jsx:

```diff
-    if (vaultUpFile.size > 5 * 1024 * 1024) {
-      setVaultUpStatus({ok:false, msg:`❌ File too large (${...}) — max 5 MB`});
+    const MAX_UPLOAD_BYTES = 10_000_000;
+    if (vaultUpFile.size > MAX_UPLOAD_BYTES) {
+      setVaultUpStatus({ok:false, msg:`❌ File too large (${...}) — max 10 MB`});
```

```diff
-  <label>PDF File <span>(max 5 MB)</span></label>
+  <label>PDF File <span>(max 10 MB)</span></label>
```

Comment in the JS guard points to the backend constants so a future bump on either side surfaces the drift loudly.

## Test plan

- [x] `vite build` clean — bundle unchanged (674.36 kB / 189.20 kB gzip)
- [x] Existing `test_vault_hardening.py` already exercises the 10 MB boundary on the backend
- [ ] Upload a 7 MB PDF after deploy → succeeds (was failing client-side before)
- [ ] Upload a 12 MB PDF → still rejected with the new 10 MB message

## Note

Found this while auditing CLAUDE.md drift. Followup PR will correct CLAUDE.md's claim that the vault UI "isn't built" and that "no pytest suite" exists (there are 197 passing tests, including `test_vault_hardening.py` which would have caught a regression of this exact constant).

https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr)_