### PR TITLE
fix(vault): cap job_description payload at 50KB — closes #41

### DIFF
--- a/backend/routes/vault_routes.py
+++ b/backend/routes/vault_routes.py
@@ -71,6 +71,14 @@ MAX_PDF_BYTES = 10_000_000
 # but rejecting early gives the caller a clearer error and avoids spending
 # CPU on absurd inputs.
 MAX_FIELD_LEN = 80
+# Issue #41 — job_description payload cap.
+# /api/vault/best-match runs TF-IDF over the whole vault (~95 resumes) +
+# the JD, so its compute cost scales with len(jd). Without a cap, a single
+# multi-megabyte string forces a full tokenization + TF-IDF rebuild +
+# N cosine sims — the highest-leverage DoS vector against the free-tier
+# Render dyno. 50_000 chars ≈ 10k tokens is roomy for any real JD
+# (the longest staffing pages on the public ATSes top out around 8k chars).
+MAX_JD_BYTES = 50_000
 
 # Comma-separated list of allowed origins. Empty/unset = legacy "*" with warning.
 ALLOWED_ORIGINS = [
@@ -315,6 +323,11 @@ def vault_job_fit():
     jd = data.get("job_description", "").strip()
     if not vk or not jd:
         return jsonify({"error": "version_key and job_description required"}), 400
+    # Issue #41 — refuse oversized payloads. 413 = Payload Too Large.
+    if len(jd) > MAX_JD_BYTES:
+        return jsonify({
+            "error": f"job_description too long ({len(jd)} chars; max {MAX_JD_BYTES})"
+        }), 413
 
     result = compare_resume_to_job(vk, jd, db_path=DB_PATH)
     return jsonify(result), 200
@@ -346,6 +359,13 @@ def vault_best_match():
     jd = data.get("job_description", "").strip()
     if not jd:
         return jsonify({"error": "job_description required"}), 400
+    # Issue #41 — refuse oversized payloads. Best-match is the most expensive
+    # vault endpoint (TF-IDF rebuild over all ~95 resumes + the JD), so the
+    # JD cap matters most here. 413 = Payload Too Large.
+    if len(jd) > MAX_JD_BYTES:
+        return jsonify({
+            "error": f"job_description too long ({len(jd)} chars; max {MAX_JD_BYTES})"
+        }), 413
 
     raw_top_n = data.get("top_n")
     try:

--- a/backend/tests/test_vault_routes.py
+++ b/backend/tests/test_vault_routes.py
@@ -286,3 +286,65 @@ def test_best_match_missing_jd_still_400(client):
     resp = client.post("/api/vault/best-match", json={"top_n": 5})
     assert resp.status_code == 400
     assert "job_description" in resp.get_json()["error"]
+
+
+# --- Issue #41: job_description payload cap ---------------------------
+# Both /api/vault/best-match and /api/vault/job-fit gate on MAX_JD_BYTES
+# to stop DoS-via-megabyte-JD against the free-tier Render dyno.
+
+
+def test_best_match_jd_at_cap_accepted(client):
+    """Exactly MAX_JD_BYTES should PASS — boundary is inclusive at the limit."""
+    from routes.vault_routes import MAX_JD_BYTES
+    jd = "x " * (MAX_JD_BYTES // 2)  # ~MAX_JD_BYTES chars, well-formed tokens
+    jd = jd[:MAX_JD_BYTES]            # trim to exact cap
+    assert len(jd) == MAX_JD_BYTES
+    resp = client.post("/api/vault/best-match", json={"job_description": jd})
+    assert resp.status_code == 200
+
+
+def test_best_match_jd_one_over_cap_rejected(client):
+    """One byte over MAX_JD_BYTES → 413 Payload Too Large."""
+    from routes.vault_routes import MAX_JD_BYTES
+    jd = "x" * (MAX_JD_BYTES + 1)
+    resp = client.post("/api/vault/best-match", json={"job_description": jd})
+    assert resp.status_code == 413
+    body = resp.get_json()
+    assert "too long" in body["error"]
+    assert str(MAX_JD_BYTES) in body["error"]
+
+
+def test_best_match_jd_massive_rejected_without_compute(client, monkeypatch):
+    """A 5MB JD must be rejected BEFORE find_best_resume_for_job is called.
+    If the cap fires lazily we'd still pay tokenization + TF-IDF cost,
+    which is the whole point of #41."""
+    import storage.resume_vault as rv
+    call_count = {"n": 0}
+
+    def boom(*args, **kwargs):
+        call_count["n"] += 1
+        return []
+    monkeypatch.setattr(rv, "find_best_resume_for_job", boom)
+
+    jd = "x" * 5_000_000  # 5MB
+    resp = client.post("/api/vault/best-match", json={"job_description": jd})
+    assert resp.status_code == 413
+    assert call_count["n"] == 0, "expected JD cap to fire before any TF-IDF work"
+
+
+def test_job_fit_jd_one_over_cap_rejected(client, monkeypatch):
+    """Same cap on /api/vault/job-fit. compare_resume_to_job must not run."""
+    import storage.resume_vault as rv
+    call_count = {"n": 0}
+
+    def boom(*args, **kwargs):
+        call_count["n"] += 1
+        return {}
+    monkeypatch.setattr(rv, "compare_resume_to_job", boom)
+
+    from routes.vault_routes import MAX_JD_BYTES
+    jd = "x" * (MAX_JD_BYTES + 1)
+    resp = client.post("/api/vault/job-fit",
+                       json={"version_key": "any_key", "job_description": jd})
+    assert resp.status_code == 413
+    assert call_count["n"] == 0


### PR DESCRIPTION
Closes #41.

## Why

`/api/vault/best-match` is the most expensive endpoint in the vault: each call tokenizes the JD, builds a TF-IDF matrix over all ~95 resumes + the JD, and runs cosine similarity for every pair. The earlier `top_n=50` cap (#38) only sliced the **response**, not the **compute** — so a single multi-megabyte string still paid the full tokenization + matrix-rebuild + N cosine cost. On Render's free-tier dyno (512 MB / shared CPU) this is the highest-leverage DoS vector against the service.

Same compute profile, smaller scale, applies to `/api/vault/job-fit`.

## Fix

```python
# backend/routes/vault_routes.py
MAX_JD_BYTES = 50_000  # ≈10k tokens; well above any real JD

# Inside vault_best_match + vault_job_fit, BEFORE any work:
if len(jd) > MAX_JD_BYTES:
    return jsonify({
        "error": f"job_description too long ({len(jd)} chars; max {MAX_JD_BYTES})"
    }), 413
```

Why 50 KB: public-ATS staffing pages I sampled top out around 8 KB; 50 KB leaves headroom for unusually verbose roles + tokenization overhead. `413` is the correct status (RFC 7231 "Payload Too Large"). Error response includes both the actual length and the cap so legit callers debugging an oversized JD get an actionable message.

## Tests (4 new)

| Test | Asserts |
|---|---|
| `test_best_match_jd_at_cap_accepted` | Exactly `MAX_JD_BYTES` passes — boundary is inclusive |
| `test_best_match_jd_one_over_cap_rejected` | `MAX_JD_BYTES + 1` → 413 with both len and cap in error |
| `test_best_match_jd_massive_rejected_without_compute` | 5MB JD must not invoke the ranker — proves the cap is the FIRST gate, not lazy. Uses a monkeypatched ranker that counts calls; asserts `0`. |
| `test_job_fit_jd_one_over_cap_rejected` | Same guarantee on `/job-fit`; counts that `compare_resume_to_job` is never called |

The third test is the critical one — it catches the failure mode where someone adds the cap but accidentally invokes the expensive function first, defeating the whole point of the issue.

## Test plan

- [x] `pytest backend/tests/test_vault_routes.py -q` — 31 pass (27 + 4 new)
- [x] `pytest backend/tests/ -q` — full suite 201 pass (was 197, +4 new)
- [ ] After deploy: `curl -X POST` with a 100KB JD → returns 413 with informative message
- [ ] After deploy: `curl -X POST` with a normal JD → still returns 200 with rankings (regression check)

## Note

Frontend already has a 20 000-char client-side cap (added in PR #33). This server-side cap is the real gate — the client cap was always advisory since direct API callers bypass it.

https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr)_