### PR TITLE
fix(api): /api/resume/versions/&lt;key&gt; DELETE — close #44

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -712,15 +712,70 @@ def api_get_resume_version(version_key):
 
 @app.route("/api/resume/versions/<version_key>", methods=["DELETE", "OPTIONS"])
 def api_delete_resume_version(version_key):
-    """Delete a resume version by key."""
+    """Delete a resume version by key.
+
+    Issue #44: routes through the same ``delete_vault_version`` helper as
+    ``/api/vault/version/<key>``. Previously this called the legacy
+    ``profile_manager.delete_resume_version`` which only removed the DB row,
+    orphaning the PDF + text files on disk — entries resurrected on the
+    next vault refresh because ``list_vault()`` reads disk.
+
+    Behavior matches the vault endpoint: malformed keys → 400, missing →
+    200 with ``already_gone: true`` (idempotent for retried DELETEs),
+    filesystem errors → 500 (DB row preserved so caller can retry).
+    """
     if request.method == "OPTIONS":
         return "", 204
+
+    # Reject obviously malformed keys BEFORE touching disk. Identical guard
+    # to the vault DELETE branch (routes/vault_routes.py).
+    if (
+        not version_key
+        or "\x00" in version_key
+        or "/" in version_key
+        or "\\" in version_key
+        or ".." in version_key
+    ):
+        return jsonify({"error": f"Invalid version_key: {version_key!r}"}), 400, \
+            {"Access-Control-Allow-Origin": "*"}
+
+    from storage.db import get_conn, get_resume_version
+    from storage.resume_vault import delete_vault_version, list_vault
+
+    # Idempotency: if neither a DB row nor a PDF on disk maps to this key,
+    # treat as success (already gone). Mirrors the vault endpoint contract.
+    conn = get_conn(DB_PATH)
+    rv = get_resume_version(conn, version_key)
+    conn.close()
+    on_disk = any(f.get("version_key") == version_key for f in list_vault())
+    if not rv and not on_disk:
+        return jsonify({
+            "status": "deleted",
+            "version_key": version_key,
+            "db_row_deleted": False,
+            "pdf_deleted": False,
+            "text_deleted": False,
+            "already_gone": True,
+        }), 200, {"Access-Control-Allow-Origin": "*"}
+
     try:
-        from storage.profile_manager import delete_resume_version
-        delete_resume_version(version_key, DB_PATH)
-        return jsonify({"status": "deleted"}), 200, {"Access-Control-Allow-Origin": "*"}
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        result = delete_vault_version(version_key, db_path=DB_PATH)
+    except ValueError as e:
+        # Don't leak filesystem paths from storage-layer messages.
+        log.warning("Legacy delete '%s' rejected: %s", version_key, e)
+        return jsonify({"error": "Invalid version_key"}), 400, \
+            {"Access-Control-Allow-Origin": "*"}
+    except OSError as e:
+        log.error("Legacy delete '%s' filesystem error: %s", version_key, e)
+        return jsonify({"error": "Filesystem error while deleting version"}), 500, \
+            {"Access-Control-Allow-Origin": "*"}
+
+    # Drop absolute paths from response; keep only basename for UX.
+    pdf_path = result.pop("pdf_path", None)
+    result.pop("text_path", None)
+    result["pdf_filename"] = os.path.basename(pdf_path) if pdf_path else None
+    return jsonify({"status": "deleted", **result}), 200, \
+        {"Access-Control-Allow-Origin": "*"}
 
 
 @app.route("/api/set-pin", methods=["POST", "OPTIONS"])

--- a/backend/storage/profile_manager.py
+++ b/backend/storage/profile_manager.py
@@ -347,13 +347,11 @@ def list_resume_versions(db_path: str = DB_PATH) -> list[dict]:
     return result
 
 
-def delete_resume_version(version_key: str, db_path: str = DB_PATH):
-    """Delete a resume version by key."""
-    conn = get_conn(db_path)
-    conn.execute("DELETE FROM resume_versions WHERE version_key = ?", (version_key,))
-    conn.commit()
-    conn.close()
-    log.info("Resume version '%s' deleted", version_key)
+# Removed (issue #44): `delete_resume_version` only deleted the DB row,
+# orphaning the PDF + text files on disk. The single caller
+# (server.api_delete_resume_version) now routes through
+# storage.resume_vault.delete_vault_version, which removes all three.
+# See PR closing #44 for the consolidation rationale.
 
 
 def get_company_application_history(company_name: str, db_path: str = DB_PATH) -> dict:

--- a/backend/tests/test_legacy_delete_consistency.py
+++ b/backend/tests/test_legacy_delete_consistency.py
@@ -1,0 +1,210 @@
+"""Tests for issue #44: /api/resume/versions/<key> DELETE consistency.
+
+Before #44, the legacy ``/api/resume/versions/<key>`` DELETE only removed
+the DB row, orphaning the PDF + text files on disk — entries resurrected
+on the next vault refresh because ``list_vault()`` scans disk. The sibling
+``/api/vault/version/<key>`` DELETE was already fixed in #37 to clean up
+all three.
+
+These tests prove both endpoints now share identical behavior on
+identical input (cleans up everything; idempotent for retries; rejects
+malformed keys), routed through the same ``delete_vault_version`` helper.
+"""
+import importlib
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    """Flask test client with isolated DB + isolated vault directory.
+
+    Mirrors test_vault_delete.py's fixture so both endpoints can be exercised
+    against the same seeded state.
+    """
+    db_path = str(tmp_path / "test.db")
+    vault_dir = tmp_path / "vault"
+    (vault_dir / "pdf").mkdir(parents=True)
+    (vault_dir / "text").mkdir(parents=True)
+
+    from storage.db import init_db
+    init_db(db_path)
+
+    import storage.resume_vault as rv_mod
+    monkeypatch.setattr(rv_mod, "VAULT_DIR", str(vault_dir))
+
+    import routes.vault_routes as vr_mod
+    monkeypatch.setattr(vr_mod, "DB_PATH", db_path)
+    monkeypatch.setattr(vr_mod, "API_SECRET", "", raising=False)
+
+    import server
+    server.DB_PATH = db_path
+    server.app.config["TESTING"] = True
+
+    with server.app.test_client() as c:
+        c._test_db_path = db_path
+        c._test_vault_dir = str(vault_dir)
+        yield c
+
+    importlib.reload(server)
+
+
+def _seed_version(client, version_key="goldman_sachs_data"):
+    """Seed a complete vault entry: DB row + PDF on disk + text cache."""
+    from storage.db import get_conn, upsert_resume_version
+    from storage.resume_vault import parse_resume_filename
+
+    conn = get_conn(client._test_db_path)
+    upsert_resume_version(
+        conn,
+        version_key=version_key,
+        display_name="Goldman Sachs",
+        resume_text="Python SQL Spark data engineer.",
+        skills=["python", "sql", "spark"],
+        target_companies=["Goldman Sachs"],
+    )
+    conn.commit()
+    conn.close()
+
+    pdf_filename = f"Narendranath_{version_key}.pdf"
+    parsed = parse_resume_filename(pdf_filename)["version_key"]
+    assert parsed == version_key, (
+        f"Test fixture mismatch: {pdf_filename!r} parses to {parsed!r}, "
+        f"expected {version_key!r}"
+    )
+
+    pdf_path = os.path.join(client._test_vault_dir, "pdf", pdf_filename)
+    with open(pdf_path, "wb") as f:
+        f.write(b"%PDF-1.4\nfake pdf bytes\n%%EOF\n")
+
+    text_path = os.path.join(client._test_vault_dir, "text", f"{version_key}.txt")
+    with open(text_path, "w") as f:
+        f.write("Python SQL Spark data engineer.")
+
+    return {"pdf_path": pdf_path, "text_path": text_path}
+
+
+def _row_exists(client, version_key):
+    from storage.db import get_conn, get_resume_version
+    conn = get_conn(client._test_db_path)
+    rv = get_resume_version(conn, version_key)
+    conn.close()
+    return rv is not None
+
+
+# ─────────────────────────────────────────────────────────────────────
+#  Core fix: PDF + text + DB row all removed (was: only DB row)
+# ─────────────────────────────────────────────────────────────────────
+
+def test_legacy_delete_removes_pdf_text_and_db_row(client):
+    """The whole point of #44: legacy endpoint must clean up disk too."""
+    paths = _seed_version(client, version_key="goldman_sachs_data")
+    assert os.path.exists(paths["pdf_path"])
+    assert os.path.exists(paths["text_path"])
+    assert _row_exists(client, "goldman_sachs_data")
+
+    resp = client.delete("/api/resume/versions/goldman_sachs_data")
+    assert resp.status_code == 200
+
+    # All three artifacts gone — this was the bug.
+    assert not os.path.exists(paths["pdf_path"]), \
+        "PDF file leaked on disk — issue #44 not fixed"
+    assert not os.path.exists(paths["text_path"]), \
+        "text cache leaked on disk — issue #44 not fixed"
+    assert not _row_exists(client, "goldman_sachs_data")
+
+
+def test_legacy_delete_response_shape_matches_vault_delete(client):
+    """Same fields, same casing — both endpoints should return identical shapes
+    for the same input, since they route through the same helper."""
+    _seed_version(client, version_key="meta_ml")
+    legacy = client.delete("/api/resume/versions/meta_ml")
+    assert legacy.status_code == 200
+    body = legacy.get_json()
+    # These keys are exactly what /api/vault/version/<key> returns post-#37.
+    assert body["status"] == "deleted"
+    assert body["version_key"] == "meta_ml"
+    assert body["db_row_deleted"] is True
+    assert body["pdf_deleted"] is True
+    assert body["text_deleted"] is True
+    assert body["pdf_filename"] == "Narendranath_meta_ml.pdf"
+    # No absolute paths leaked.
+    assert "pdf_path" not in body
+    assert "text_path" not in body
+
+
+# ─────────────────────────────────────────────────────────────────────
+#  Idempotency: retried DELETE on already-gone version
+# ─────────────────────────────────────────────────────────────────────
+
+def test_legacy_delete_idempotent_when_already_gone(client):
+    """Retried DELETE on a missing version → 200 with already_gone:true.
+
+    Same contract as the vault endpoint — DELETE's post-condition is
+    'resource does not exist', so a never-existed key satisfies it.
+    """
+    resp = client.delete("/api/resume/versions/never_existed")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["already_gone"] is True
+    assert body["db_row_deleted"] is False
+    assert body["pdf_deleted"] is False
+
+
+# ─────────────────────────────────────────────────────────────────────
+#  Malformed keys rejected at the route, not the storage layer
+# ─────────────────────────────────────────────────────────────────────
+
+# Two layers of rejection: Flask's <string:> URL converter refuses keys
+# containing "/", returning 404 at the routing layer before our handler runs.
+# Keys without "/" reach the handler and get rejected with 400. Both stop
+# the attack — we just test the route they take is the one we expect.
+
+@pytest.mark.parametrize("bad_key", [
+    "..",            # bare ".." — reaches handler
+    "foo\\bar",      # backslash — reaches handler
+    "foo\x00bar",    # null byte — reaches handler
+])
+def test_legacy_delete_rejects_malformed_keys_at_handler(client, bad_key):
+    """Path-traversal keys without "/" hit our handler and get 400."""
+    from urllib.parse import quote
+    resp = client.delete(f"/api/resume/versions/{quote(bad_key, safe='')}")
+    assert resp.status_code == 400, f"{bad_key!r} should be rejected with 400"
+    body = resp.get_json()
+    assert "version_key" in body["error"].lower() or "invalid" in body["error"].lower()
+
+
+@pytest.mark.parametrize("bad_key", [
+    "../etc/passwd",  # contains "/"
+    "foo/../bar",     # contains "/"
+])
+def test_legacy_delete_slash_keys_blocked_by_flask_router(client, bad_key):
+    """Keys with "/" are stopped by Flask's <string:> converter before
+    reaching our code (404 routing miss). Different status code, same
+    practical outcome — the attack never lands."""
+    from urllib.parse import quote
+    resp = client.delete(f"/api/resume/versions/{quote(bad_key, safe='')}")
+    # The URL splits at the encoded /, so Flask routes it to a non-existent
+    # path → 404. We just confirm the request doesn't succeed.
+    assert resp.status_code in (404, 405, 400), \
+        f"{bad_key!r} unexpectedly returned {resp.status_code}"
+
+
+# ─────────────────────────────────────────────────────────────────────
+#  Regression: the function deleted from profile_manager stays deleted
+# ─────────────────────────────────────────────────────────────────────
+
+def test_legacy_profile_manager_delete_helper_removed():
+    """profile_manager.delete_resume_version was the bug — make sure no one
+    accidentally re-adds it without routing through delete_vault_version."""
+    import storage.profile_manager as pm
+    assert not hasattr(pm, "delete_resume_version"), (
+        "profile_manager.delete_resume_version was removed in #44. "
+        "If a new caller needs to delete a vault version, use "
+        "storage.resume_vault.delete_vault_version which cleans up "
+        "the PDF + text + DB row together."
+    )


### PR DESCRIPTION
Closes #44.

## The bug

Two DELETE endpoints with semantically different behavior on the same data:

| Endpoint | Removes |
|---|---|
| `/api/vault/version/<key>` | ✅ PDF + text cache + DB row (fixed in #37) |
| `/api/resume/versions/<key>` | ❌ DB row only — PDFs & text caches orphaned |

Since `list_vault()` scans the filesystem, deleting via the legacy endpoint produced the same #37 zombie behavior: entry resurrects on the next vault refresh. The frontend's Tracker tab uses the legacy endpoint (`App.jsx:1923`), so this was user-visible.

## Fix

`server.api_delete_resume_version` now routes through the same `storage.resume_vault.delete_vault_version` helper as the vault endpoint. Behaviors are now byte-identical:

| Input | Response |
|---|---|
| Successful delete | `200 {status: "deleted", db_row_deleted, pdf_deleted, text_deleted, pdf_filename}` |
| Already gone | `200 {status: "deleted", already_gone: true, ...}` (idempotent for queue retries) |
| Malformed key (null byte, `\`, `..`) | `400 {error: "Invalid version_key"}` (no path leakage) |
| Slash-containing key | `404`/`405` from Flask router (different layer, same outcome — attack doesn't land) |
| Filesystem failure | `500 {error: "Filesystem error..."}` — DB row preserved so caller can retry |

Also **removed** the now-orphaned `profile_manager.delete_resume_version` (single caller was the route I just rewired). Replaced with a code comment pointing future readers at `delete_vault_version` so this regression can't quietly come back.

## Tests (9 new in `test_legacy_delete_consistency.py`)

- `test_legacy_delete_removes_pdf_text_and_db_row` — the core fix, asserts all three artifacts gone
- `test_legacy_delete_response_shape_matches_vault_delete` — proves shape parity with the sibling endpoint
- `test_legacy_delete_idempotent_when_already_gone` — retried DELETE on missing version → 200
- `test_legacy_delete_rejects_malformed_keys_at_handler` (parametrized × 3: `..`, `\\bar`, null byte)
- `test_legacy_delete_slash_keys_blocked_by_flask_router` (parametrized × 2)
- `test_legacy_profile_manager_delete_helper_removed` — regression guard: if anyone re-adds the legacy function without routing through the vault helper, this test fails with a doc comment explaining why

## Test plan

- [x] `pytest tests/test_legacy_delete_consistency.py -q` — 9 pass
- [x] `pytest tests/ -q` — 210 pass total (was 201)
- [ ] After deploy: delete a resume from the Tracker tab → refresh page → entry stays gone (previously came back)
- [ ] After deploy: delete a resume from the Vault tab → refresh → still works as before (regression check on the un-touched code path)

https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr)_