### PR TITLE
feat(scraper): bump Workday roster 9 → 15 + validation tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@
 
 A production-grade, zero-cost **end-to-end job hunt automation platform** for Data Engineers and ML Engineers. The system covers the full lifecycle:
 
-1. **Discover** — Scrape 147 company career pages across 6 ATS platforms every 5 minutes
+1. **Discover** — Scrape 153 company career pages across 6 ATS platforms every 5 minutes
 2. **Score** — Rate every job against your resume using multi-signal relevance + TF-IDF scoring
 3. **Match** — Find the best resume (from 95+ tailored PDFs) for each specific job description
 4. **Alert** — Instant Discord/Telegram notifications when dream roles appear
@@ -41,7 +41,7 @@ A production-grade, zero-cost **end-to-end job hunt automation platform** for Da
 ┌─────────────────────────────────────────┬──────────────────────┐
 │               Layer                     │        Status        │
 ├─────────────────────────────────────────┼──────────────────────┤
-│ Scraping 147 companies (6 ATS)          │ ✅ Live              │
+│ Scraping 153 companies (6 ATS)          │ ✅ Live              │
 │ Hourly GitHub Actions cron              │ ✅ Running           │
 │ Flask API + all base endpoints          │ ✅ Live on Render    │
 │ Resume vault backend (9 endpoints)      │ ✅ Live + auth-gated │
@@ -104,7 +104,7 @@ and the default-resume selector. Search App.jsx for `jobFitByJob`,
 │                  RENDER (FREE TIER)                   │
 │  Flask (server.py — 847 lines) + Background Thread    │
 │  ├── Every 5 min:  Tier 0+1 (58 dream companies)     │
-│  ├── Every 60 min: All tiers (full 147-company sweep) │
+│  ├── Every 60 min: All tiers (full 153-company sweep) │
 │  ├── Night skip:   12am–5:30am CST (06:00–11:30 UTC) │
 │  ├── Dream alerts: Discord + Telegram on new match    │
 │  └── SQLite DB (WAL mode):                            │
@@ -161,7 +161,7 @@ job-scout/
 │   │   ├── ashby.py               # ~11 companies
 │   │   ├── smartrecruiters.py     # ~4 companies
 │   │   ├── bamboohr.py            # ~3 companies
-│   │   └── workday.py             # ~7 finance/enterprise companies (POST API)
+│   │   └── workday.py             # ~15 finance/enterprise companies (POST API)
 │   ├── core/
 │   │   └── relevance.py           # Multi-signal scoring engine (0–1.0)
 │   ├── storage/
@@ -325,7 +325,7 @@ Every yielded dict must contain: `external_id`, `title`, `company`, `location`, 
 | `ashby.py` | Ashby | `GET api.ashbyhq.com/posting-api/job-board/{slug}` | ~11 |
 | `smartrecruiters.py` | SmartRecruiters | `GET api.smartrecruiters.com/v1/companies/{slug}/postings` | ~4 |
 | `bamboohr.py` | BambooHR | `GET {slug}.bamboohr.com/careers/list` | ~3 |
-| `workday.py` | Workday | `POST {host}/wday/cxs/{slug}/{board}/jobs` | ~7 |
+| `workday.py` | Workday | `POST {host}/wday/cxs/{slug}/{board}/jobs` | ~15 |
 
 ### Tier system (companies.py — 147 total companies across 4 tiers)
 - **Tier 0 (28 companies):** Top-of-mind dream companies — scraped every cycle alongside Tier 1
@@ -570,20 +570,25 @@ React 18 + Vite + Recharts. Single-file component.
 
 1. App.jsx is 3882 lines — should split into per-tab modules (**urgent** — well past sustainable size)
 2. server.py is 847 lines — monolithic
-3. pdfplumber (server.py) vs pypdf (vault) — two PDF libraries, should standardize
-4. Workday coverage only 7 companies
-5. AutoApply end-to-end loop never validated on a real ATS page
-6. Work history not in a queryable database yet
-7. No portal form field mapping per ATS (each has different DOM)
+3. AutoApply end-to-end loop never validated on a real ATS page
+4. Work history not in a queryable database yet
+5. No portal form field mapping per ATS (each has different DOM)
 
 Resolved (no longer debt):
 - ~~Vault has no dashboard UI~~ — full tab + best-match + chip + upload + compare all wired
-- ~~No pytest suite~~ — 17 test files, 210 passing tests covering vault hardening,
+- ~~No pytest suite~~ — 17 test files, 219 passing tests covering vault hardening,
   relevance, scrape orchestrator, applications API, admin routes, profile manager,
-  the new JD-payload cap (#41), and the unified DELETE behavior (#44)
+  the new JD-payload cap (#41), the unified DELETE behavior (#44),
+  the pypdf consolidation (#58), and Workday URL-triple validation (#59)
 - ~~Untracked resume files at repo root~~ — `resume.md` was always tracked;
   `resume-projects.md`, `resume_narendranath.tex`, `resume-personal.md` are
   gitignored on purpose (private content, never intended to commit)
+- ~~pdfplumber + pypdf coexistence~~ — pdfplumber retired; pypdf is the single
+  PDF library, with a regression test (`test_pdfplumber_no_longer_imported_anywhere`)
+  pinning the decision
+- ~~Workday coverage only 9 companies~~ — bumped to 15 (Adobe, Cisco, Mastercard,
+  Charles Schwab, BNY Mellon, State Street added). Plus 3 new test guards
+  (URL-triple completeness, valid wd_instance subdomain, no duplicate names).
 
 ---
 
@@ -692,8 +697,7 @@ Done (kept for history):
 
 Open (priority order):
 1. **Split App.jsx into per-tab modules** — biggest tech-debt item; 3882 LOC in one file
-2. Design work history PostgreSQL schema (AutoApply prerequisite)
-3. Wire up `floatingPanel.ts` in the AutoApply Chrome extension
-4. Standardize on one PDF library (pypdf preferred — already in vault)
+2. **Split server.py into route modules** — 847 LOC monolith; routes are easy to extract per Blueprint
+3. Design work history PostgreSQL schema (AutoApply prerequisite)
+4. Wire up `floatingPanel.ts` in the AutoApply Chrome extension
 5. Validate end-to-end AutoApply loop on a real ATS page
-6. Bump Workday scraper coverage from 7 → ~15 companies (most enterprises use Workday)

--- a/backend/config/companies.py
+++ b/backend/config/companies.py
@@ -235,6 +235,19 @@ COMPANIES = [
     {"name": "Target",          "ats": "workday", "slug": "target",        "wd_instance": "wd1", "wd_board": "TGT_External",    "tier": 3},
     {"name": "Deloitte",        "ats": "workday", "slug": "deloitte",      "wd_instance": "wd5", "wd_board": "DeloitteCareers", "tier": 3},
 
+    # ── Workday expansion (CLAUDE.md tech-debt #6): bumping coverage 9 → 15 ──
+    # Picked Fortune 500 employers with active Data Engineering / ML hiring
+    # that aren't already on the list under another ATS. URL format triples
+    # below were sourced from each company's public careers portal. The
+    # scraper handles 404s gracefully (logs a warning, moves on), so if any
+    # of these slugs drift in the future the scrape run isn't impacted.
+    {"name": "Adobe",           "ats": "workday", "slug": "adobe",         "wd_instance": "wd5", "wd_board": "external_experienced",       "tier": 2},
+    {"name": "Cisco",           "ats": "workday", "slug": "cisco",         "wd_instance": "wd1", "wd_board": "Cisco_Career_Site",          "tier": 2},
+    {"name": "Mastercard",      "ats": "workday", "slug": "mastercard",    "wd_instance": "wd1", "wd_board": "CorporateCareers",           "tier": 2},
+    {"name": "Charles Schwab",  "ats": "workday", "slug": "schwab",        "wd_instance": "wd1", "wd_board": "myschwabcareerportal",       "tier": 2},
+    {"name": "BNY Mellon",      "ats": "workday", "slug": "bnymellon",     "wd_instance": "wd1", "wd_board": "BNYM_Careers",               "tier": 3},
+    {"name": "State Street",    "ats": "workday", "slug": "statestreet",   "wd_instance": "wd5", "wd_board": "Global",                     "tier": 3},
+
     # ── Quant firms (AQR, HRT use custom job boards — listed for reference) ──
     # AQR:  https://careers.aqr.com  — no standard public API, apply directly
     # HRT:  https://www.hudsonrivertrading.com/careers/ — no public ATS API

--- a/backend/tests/test_companies.py
+++ b/backend/tests/test_companies.py
@@ -22,3 +22,50 @@ def test_fast_mode_includes_platinum():
     assert len(platinum) >= 5
     for co in platinum:
         assert co in fast_companies
+
+
+# ─── Workday entries must carry the URL triple the scraper needs ───
+# Without slug + wd_instance + wd_board the Workday POST URL is malformed
+# and every scrape attempt logs a 404. Catch missing fields at import time
+# instead of in production logs.
+
+def test_workday_companies_have_complete_url_triple():
+    from config.companies import COMPANIES
+    workday = [c for c in COMPANIES if c.get("ats") == "workday"]
+    assert len(workday) > 0, "expected at least one workday entry"
+    missing = []
+    for co in workday:
+        required = ("slug", "wd_instance", "wd_board")
+        gaps = [k for k in required if not co.get(k)]
+        if gaps:
+            missing.append(f"{co.get('name', '?')}: missing {gaps}")
+    assert not missing, "Workday entries with incomplete URL fields:\n  " + "\n  ".join(missing)
+
+
+def test_workday_wd_instance_is_valid_subdomain():
+    """Workday hosts companies under wd1.../wd2.../wd3.../wd5.../wd6.../wd103. ...
+    A typo'd instance produces an unreachable DNS name. Restrict to the
+    set that's actually been observed in the wild to make typos loud."""
+    from config.companies import COMPANIES
+    valid = {"wd1", "wd2", "wd3", "wd5", "wd6", "wd101", "wd102", "wd103", "wd104", "wd105"}
+    bad = [
+        f"{c.get('name')}: wd_instance={c.get('wd_instance')!r}"
+        for c in COMPANIES
+        if c.get("ats") == "workday" and c.get("wd_instance") not in valid
+    ]
+    assert not bad, (
+        "Workday entries with unrecognized wd_instance — if Workday added a "
+        "new instance prefix, extend the `valid` set in this test:\n  "
+        + "\n  ".join(bad)
+    )
+
+
+def test_no_duplicate_company_names():
+    """Catches the failure mode where a company is added to the list twice
+    under different ATSes (e.g. Salesforce on playwright AND workday).
+    Each name should appear exactly once."""
+    from collections import Counter
+    from config.companies import COMPANIES
+    counts = Counter(c["name"] for c in COMPANIES)
+    dupes = {n: c for n, c in counts.items() if c > 1}
+    assert not dupes, f"Duplicate company names: {dupes}"


### PR DESCRIPTION
## What

Bumps Workday scraper coverage **9 → 15** (CLAUDE.md tech-debt #6 target). Most Fortune 500 financial-services + enterprise companies run Workday, so this is high-leverage scraper real estate that costs us nothing per cycle.

Also drift-fix: CLAUDE.md said "Workday coverage only 7 companies" but the actual was already 9 before this PR. Updated all references.

## New companies (6 added)

| Name | Tier | wd_instance | wd_board |
|---|---|---|---|
| Adobe | 2 | wd5 | external_experienced |
| Cisco | 2 | wd1 | Cisco_Career_Site |
| Mastercard | 2 | wd1 | CorporateCareers |
| Charles Schwab | 2 | wd1 | myschwabcareerportal |
| BNY Mellon | 3 | wd1 | BNYM_Careers |
| State Street | 3 | wd5 | Global |

### Selection criteria

1. **Fortune 500 with active Data Engineering / ML / Quant hiring** — these are the roles JobScout's relevance engine scores best
2. **Not already in the config under another ATS** — verified via `grep -E '"name": *"(Salesforce|Adobe|Cisco|...)"'`. Salesforce (playwright), Visa (smartrecruiters), Fidelity (playwright) intentionally left alone
3. **URL triples sourced from public careers portals** — the `slug` + `wd_instance` + `wd_board` combination needed for the `POST {host}/wday/cxs/{slug}/{board}/jobs` API

### Robustness

The scraper already handles 404 gracefully at `backend/scrapers/workday.py:84-86`:
```python
if resp.status_code == 404:
    log.warning("Workday %s: board not found (%s)", name, api_url)
    return  # This company config is wrong — stop entirely
```

So if any of these triples drift over time, the worst case is one warning per cycle per misconfigured entry — no impact on the rest of the run.

## Tests (3 new in `test_companies.py`)

| Test | Catches |
|---|---|
| `test_workday_companies_have_complete_url_triple` | Workday entries missing any of slug / wd_instance / wd_board — these would silently produce malformed POST URLs and 404s in production |
| `test_workday_wd_instance_is_valid_subdomain` | Typo'd instance prefixes like `"wd4"` or `"wd10"` that hit unreachable DNS. Allowlist: wd1, wd2, wd3, wd5, wd6, wd101–105 |
| `test_no_duplicate_company_names` | The failure mode where a company is added to the list twice under two different ATS values (e.g. Salesforce on both `playwright` and `workday`). Each `name` should appear exactly once. |

The duplicate-name guard would have caught real ambiguity if I'd added Salesforce to Workday — it's already there under playwright.

## CLAUDE.md sync

While I was in there, swept three more drifts:
- `147 companies` → **153** (3 spots)
- `workday.py # ~7 finance companies` → `~15`
- Scrapers-table Workday count `~7` → `~15`
- Removed two tech-debt entries that are now closed (Workday coverage; standardize PDF library — #58 just shipped)
- Added them to the Resolved subsection so the history is preserved
- Open list now ends at 5 items (was 6); priority-2 promoted to "Split server.py"

## Test plan

- [x] `pytest tests/test_companies.py -v` — 5 pass (2 existing + 3 new)
- [x] `pytest tests/ -q` — 219 pass (was 216, +3 new)
- [ ] After next scrape cycle: check Render logs for warnings on any of the 6 new entries. If a triple is wrong, fix the slug/instance/board in a follow-up PR
- [ ] Confirm new jobs from at least 2 of the 6 new companies appear in the dashboard within 24h

https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr)_