### PR TITLE
refactor(server): extract State class to core/state.py (2/8)

### DIFF
--- a/backend/core/state.py
+++ b/backend/core/state.py
@@ -1,0 +1,72 @@
+"""Shared mutable state for the JobScout server — extracted from server.py.
+
+Two consumers in this codebase:
+1. The background scrape loop (writes ``is_scraping``, ``record_cycle``,
+   ``update_cache``).
+2. Read-only route handlers (read ``health()`` for /api/health, ``get_cache``
+   for /api/data).
+
+Kept as a singleton imported from this module so routes split across
+multiple Blueprint files can all reach the same object without circular
+imports back through ``server``.
+
+Thread-safety note: GIL serializes the attribute writes inside Python,
+and the cycle counters are advisory rather than strictly accurate, so we
+deliberately don't lock. The cache assignment is atomic at the
+attribute-binding level. If a future test or production concern requires
+hard accuracy, wrap mutations in a ``threading.Lock``.
+"""
+import json
+from datetime import datetime, timezone
+
+from config.companies import TOTAL_COMPANIES
+from core.config import FAST_INTERVAL
+
+
+class State:
+    def __init__(self):
+        self.started_at = datetime.now(timezone.utc).isoformat()
+        self.last_scrape_at = None
+        self.last_duration = 0
+        self.total_cycles = 0
+        self.total_new = 0
+        self.last_error = None
+        self.is_scraping = False
+        self._cached_json = None
+        self._cached_at = None
+
+    def update_cache(self, data: dict):
+        self._cached_json = json.dumps(data, default=str, separators=(",", ":"))
+        self._cached_at = datetime.now(timezone.utc).isoformat()
+
+    def get_cache(self) -> str | None:
+        return self._cached_json
+
+    def record_cycle(self, duration: float, stats: dict, error: str = None):
+        self.last_scrape_at = datetime.now(timezone.utc).isoformat()
+        self.last_duration = round(duration, 1)
+        self.total_cycles += 1
+        self.total_new += stats.get("new", 0)
+        self.last_error = error
+        self.is_scraping = False
+
+    def health(self) -> dict:
+        return {
+            "status":            "scraping" if self.is_scraping else "idle",
+            "started_at":        self.started_at,
+            "uptime_hours":      round(
+                (datetime.now(timezone.utc) - datetime.fromisoformat(self.started_at)).total_seconds() / 3600, 1
+            ),
+            "last_scrape_at":    self.last_scrape_at,
+            "last_duration_sec": self.last_duration,
+            "total_cycles":      self.total_cycles,
+            "total_new_jobs":    self.total_new,
+            "last_error":        self.last_error,
+            "cache_fresh_at":    self._cached_at,
+            "companies_tracked": TOTAL_COMPANIES,
+            "fast_interval_sec": FAST_INTERVAL,
+        }
+
+
+# Process-wide singleton. server.py re-exports this for backward compat.
+state = State()

--- a/backend/server.py
+++ b/backend/server.py
@@ -37,9 +37,9 @@ from core.scrape_status import broker
 from core.scrape_orchestrator import run_scrape
 from storage.db import init_db, get_conn, get_stats
 
-# CLAUDE.md tech-debt #2 — server.py split. Shared constants now live in
-# core/config.py so new route blueprints can import them without having
-# to import server itself (which would cause circular imports).
+# CLAUDE.md tech-debt #2 — server.py split. Shared constants and state
+# now live in core/* so new route blueprints can import them without
+# having to import server itself (which would cause circular imports).
 # Re-exported here for now so existing routes keep working unchanged;
 # each subsequent extraction PR will swap the in-file references over.
 from core.config import (
@@ -50,6 +50,7 @@ from core.config import (
     _BEARER_RE,
     check_api_secret,
 )
+from core.state import State, state
 
 logging.basicConfig(
     level=logging.INFO,
@@ -68,53 +69,9 @@ from routes.admin_routes import admin_bp
 app.register_blueprint(admin_bp)
 
 
-# ─── Shared State ──────────────────────────────────────────────────
-class State:
-    def __init__(self):
-        self.started_at   = datetime.now(timezone.utc).isoformat()
-        self.last_scrape_at = None
-        self.last_duration  = 0
-        self.total_cycles   = 0
-        self.total_new      = 0
-        self.last_error     = None
-        self.is_scraping    = False
-        self._cached_json   = None
-        self._cached_at     = None
-
-    def update_cache(self, data: dict):
-        self._cached_json = json.dumps(data, default=str, separators=(",", ":"))
-        self._cached_at   = datetime.now(timezone.utc).isoformat()
-
-    def get_cache(self) -> str | None:
-        return self._cached_json
-
-    def record_cycle(self, duration: float, stats: dict, error: str = None):
-        self.last_scrape_at = datetime.now(timezone.utc).isoformat()
-        self.last_duration  = round(duration, 1)
-        self.total_cycles  += 1
-        self.total_new     += stats.get("new", 0)
-        self.last_error     = error
-        self.is_scraping    = False
-
-    def health(self) -> dict:
-        return {
-            "status":            "scraping" if self.is_scraping else "idle",
-            "started_at":        self.started_at,
-            "uptime_hours":      round(
-                (datetime.now(timezone.utc) - datetime.fromisoformat(self.started_at)).total_seconds() / 3600, 1
-            ),
-            "last_scrape_at":    self.last_scrape_at,
-            "last_duration_sec": self.last_duration,
-            "total_cycles":      self.total_cycles,
-            "total_new_jobs":    self.total_new,
-            "last_error":        self.last_error,
-            "cache_fresh_at":    self._cached_at,
-            "companies_tracked": TOTAL_COMPANIES,
-            "fast_interval_sec": FAST_INTERVAL,
-        }
-
-
-state = State()
+# State + state singleton are imported above from core.state (PR 2/8).
+# Kept the import block compact so future readers see all shared deps in
+# one place at the top of the file rather than scattered through.
 
 # ─── Night quiet hours ────────────────────────────────────────────
 def is_quiet_hours() -> bool:


### PR DESCRIPTION
PR 2 of 8 — server.py split (CLAUDE.md tech-debt #2).

Moves the shared mutable `State` class and its `state = State()` singleton out of `server.py` to a neutral leaf module. After this PR, upcoming route extractions can `from core.state import state` without circular-importing `server` itself.

## What moves

| | From | To |
|---|---|---|
| `State` class (47 LOC) | `server.py:74-118` | `core/state.py:25-72` |
| `state = State()` singleton | `server.py:119` | `core/state.py:75` |

## Why a singleton (not a per-request object)

Two threads need to read/write this:
1. **Background scraper** writes `is_scraping`, `record_cycle()`, `update_cache()`
2. **Read-only routes** read `health()` for `/api/health`, `get_cache()` for `/api/data`

A process-wide singleton is the simplest correct primitive. Thread-safety is deliberately unchanged from the pre-refactor behavior — GIL serializes attribute writes, the cycle counters are advisory rather than strictly accurate. Documented in the new module's docstring so a future contributor knows the trade-off if hard accuracy becomes required.

## server.py changes

- 47-LOC inline class definition deleted
- One new import line: `from core.state import State, state`
- One comment block explaining the relocation
- Net: server.py shrinks by ~45 LOC

## Test plan

- [x] `pytest backend/tests/ -q` — 219 passed (unchanged)
- [x] No test fixture needed changes — `server.state`, `state.health()`, etc. all still work because `server.py` re-exports the singleton
- [ ] After deploy: `/api/health` returns the same shape and `total_cycles` increments correctly after a scrape cycle (the exact behavior unchanged by this refactor)

## Progress

```
✅ 1/8  core/config.py             (PR #60)
✅ 2/8  core/state.py              (this PR)
⏳ 3/8  core/scrape_loop.py
⏳ 4/8  routes/data_routes.py
⏳ 5/8  routes/scrape_routes.py
⏳ 6/8  routes/profile_routes.py
⏳ 7/8  routes/application_routes.py
⏳ 8/8  routes/resume_version_routes.py
```

server.py: 905 LOC → ~810 LOC after this PR.

https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr)_