### PR TITLE
refactor(server): extract background scrape loop to core/scrape_loop.py (3/8)

### DIFF
--- a/backend/core/scrape_loop.py
+++ b/backend/core/scrape_loop.py
@@ -1,0 +1,146 @@
+"""Background scrape loop + cache rebuild — extracted from server.py.
+
+This module owns everything the daemon scraper thread needs:
+- Quiet-hours detection (12am–5:30am CST)
+- Cache rebuild after each cycle
+- Fast-mode batch sizing
+- Async scrape runner (used both by the loop and by /api/scrape)
+- The loop itself + its enable-gate
+
+Why a separate module: the daemon thread mutates the shared State
+singleton, and POST /api/scrape calls into _run_scrape_async too. Routes
+moving into their own Blueprint files in the upcoming split need to
+import this without circular-importing server.py.
+
+Side effects:
+- Reads core.config (DB_PATH, FAST_INTERVAL)
+- Mutates core.state.state
+- Calls core.scrape_orchestrator.run_scrape
+- Drives core.scrape_status.broker
+"""
+import logging
+import os
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+
+from config.companies import COMPANIES
+from core.config import DB_PATH, FAST_INTERVAL
+from core.scrape_status import broker
+from core.scrape_orchestrator import run_scrape
+from core.state import state
+from storage.db import get_conn
+
+log = logging.getLogger("jobscout")
+
+
+def is_quiet_hours() -> bool:
+    """
+    Returns True during 12:00am–5:30am CST (06:00–11:30 UTC).
+    No new roles are typically posted overnight, so we skip scraping.
+    """
+    now = datetime.now(timezone.utc)
+    utc_mins = now.hour * 60 + now.minute
+    # 12:00am CST = 06:00 UTC = 360 min
+    # 05:30am CST = 11:30 UTC = 690 min
+    return 360 <= utc_mins < 690
+
+
+def build_cache():
+    """Rebuild JSON cache from DB after each scrape.
+
+    Called by:
+    - _run_scrape_async after each cycle completes
+    - api_data route on cache miss (cold start before first scrape)
+    """
+    try:
+        from export_data import export
+        data = export(DB_PATH)
+        state.update_cache(data)
+        log.info("Cache rebuilt — %d jobs", data.get("stats", {}).get("total_jobs", 0))
+    except Exception as e:
+        log.error("Cache rebuild failed: %s", e)
+
+
+def count_fast_companies() -> int:
+    """Number of companies in 'fast' mode — Tier 0/1. Computed here so we can
+    pre-arm the broker with the real total inside the request handler, before
+    the worker thread starts. Keeps the snapshot returned by POST /api/scrape
+    immediately useful for the dashboard."""
+    return sum(1 for c in COMPANIES if c.get("tier", 3) in (0, 1))
+
+
+def run_scrape_async(mode: str = "fast") -> None:
+    """Background runner: executes a scrape, records cycle stats, rebuilds cache.
+
+    SQLite connections are not thread-safe, so we open `conn` here inside the
+    worker thread rather than reusing one from the request thread. The
+    orchestrator's own try/finally guarantees broker.finish(); the inner
+    try/finally closes the conn even if the orchestrator raises. The outer
+    try/except mirrors that for state.is_scraping so it's always cleared.
+    """
+    state.is_scraping = True
+    t0 = time.time()
+    try:
+        conn = get_conn(DB_PATH)
+        try:
+            stats = run_scrape(conn, mode=mode, status_broker=broker)
+        finally:
+            conn.close()
+        state.record_cycle(time.time() - t0, stats)
+        build_cache()
+    except Exception as e:
+        log.exception("Async scrape failed")
+        state.record_cycle(0, {}, str(e))
+    finally:
+        # record_cycle() already clears is_scraping; keep this for the
+        # exception-before-record_cycle window.
+        state.is_scraping = False
+
+
+def bg_scrape_loop() -> None:
+    """The daemon thread that scrapes every FAST_INTERVAL seconds during
+    business hours. Designed to be unkillable — exceptions are logged and
+    the loop continues so a transient ATS failure doesn't take down the
+    whole scheduler."""
+    log.info("Background scraper enabled — interval=%ds", FAST_INTERVAL)
+    # First tick gets a short delay so the Flask boot path isn't competing
+    # with the scraper for SQLite init/imports on cold starts.
+    time.sleep(15)
+    while True:
+        try:
+            if is_quiet_hours():
+                log.debug("BG scrape: quiet hours, skipping")
+            elif not broker.try_start("fast", count_fast_companies()):
+                # Atomic check-and-arm: must mirror POST /api/scrape's gate
+                # exactly. A plain `if broker.is_running()` check would leave
+                # a race window where a manual POST wins the broker while
+                # we're about to call run_scrape() — both threads would then
+                # tick the same broker and double-scrape the same companies.
+                log.debug("BG scrape: broker busy, skipping cycle")
+            else:
+                log.info("BG scrape: starting fast cycle")
+                threading.Thread(
+                    target=run_scrape_async,
+                    args=("fast",),
+                    daemon=True,
+                    name="bg-scrape-worker",
+                ).start()
+        except Exception:
+            # Never let the loop die — log and continue. The 10-min watchdog
+            # in StatusBroker.is_running() rescues us if a scrape crashed
+            # before its finally-finish() ran.
+            log.exception("BG scrape loop tick failed")
+        time.sleep(FAST_INTERVAL)
+
+
+def should_run_bg_scraper() -> bool:
+    """Background loop is opt-out via DISABLE_BG_SCRAPE=1, and auto-disabled
+    under pytest so test_client() reloads don't spawn rogue threads that
+    write to the test DB."""
+    if "PYTEST_CURRENT_TEST" in os.environ or "pytest" in sys.modules:
+        return False
+    if os.environ.get("DISABLE_BG_SCRAPE", "").lower() in ("1", "true", "yes"):
+        return False
+    return os.environ.get("ENABLE_BG_SCRAPE", "1") == "1"

--- a/backend/server.py
+++ b/backend/server.py
@@ -51,6 +51,17 @@ from core.config import (
     check_api_secret,
 )
 from core.state import State, state
+# Background scraper + cache rebuild extracted to core/scrape_loop.py (PR 3/8).
+# Kept as re-exports here so existing route bodies still work; will be
+# inlined-via-import in the per-route-blueprint extractions.
+from core.scrape_loop import (
+    is_quiet_hours,
+    build_cache,
+    count_fast_companies as _count_fast_companies,
+    run_scrape_async as _run_scrape_async,
+    bg_scrape_loop as _bg_scrape_loop,
+    should_run_bg_scraper as _should_run_bg_scraper,
+)
 
 logging.basicConfig(
     level=logging.INFO,
@@ -73,29 +84,7 @@ app.register_blueprint(admin_bp)
 # Kept the import block compact so future readers see all shared deps in
 # one place at the top of the file rather than scattered through.
 
-# ─── Night quiet hours ────────────────────────────────────────────
-def is_quiet_hours() -> bool:
-    """
-    Returns True during 12:00am–5:30am CST (06:00–11:30 UTC).
-    No new roles are typically posted overnight, so we skip scraping.
-    """
-    now = datetime.now(timezone.utc)
-    utc_mins = now.hour * 60 + now.minute
-    # 12:00am CST = 06:00 UTC = 360 min
-    # 05:30am CST = 11:30 UTC = 690 min
-    return 360 <= utc_mins < 690
-
-
-def build_cache():
-    """Rebuild JSON cache from DB after each scrape."""
-    try:
-        from export_data import export
-        data = export(DB_PATH)
-        state.update_cache(data)
-        log.info("Cache rebuilt — %d jobs", data.get("stats", {}).get("total_jobs", 0))
-    except Exception as e:
-        log.error("Cache rebuild failed: %s", e)
-
+# is_quiet_hours + build_cache imported above from core.scrape_loop (PR 3/8).
 
 # ─── Flask routes ─────────────────────────────────────────────────
 
@@ -133,41 +122,7 @@ def api_stats():
         return jsonify({"error": str(e)}), 500
 
 
-def _count_fast_companies() -> int:
-    """Number of companies in 'fast' mode — Tier 0/1. Computed here so we can
-    pre-arm the broker with the real total inside the request handler, before
-    the worker thread starts. Keeps the snapshot returned by POST /api/scrape
-    immediately useful for the dashboard."""
-    return sum(1 for c in COMPANIES if c.get("tier", 3) in (0, 1))
-
-
-def _run_scrape_async(mode: str = "fast") -> None:
-    """Background runner: executes a scrape, records cycle stats, rebuilds cache.
-
-    SQLite connections are not thread-safe, so we open `conn` here inside the
-    worker thread rather than reusing one from the request thread. The
-    orchestrator's own try/finally guarantees broker.finish(); the inner
-    try/finally closes the conn even if the orchestrator raises. The outer
-    try/except mirrors that for state.is_scraping so it's always cleared.
-    """
-    state.is_scraping = True
-    t0 = time.time()
-    try:
-        conn = get_conn(DB_PATH)
-        try:
-            stats = run_scrape(conn, mode=mode, status_broker=broker)
-        finally:
-            conn.close()
-        state.record_cycle(time.time() - t0, stats)
-        build_cache()
-    except Exception as e:
-        log.exception("Async scrape failed")
-        state.record_cycle(0, {}, str(e))
-    finally:
-        # record_cycle() already clears is_scraping; keep this for the
-        # exception-before-record_cycle window.
-        state.is_scraping = False
-
+# _count_fast_companies + _run_scrape_async imported above from core.scrape_loop.
 
 def _check_api_secret() -> bool:
     """Backward-compat shim over core.config.check_api_secret.
@@ -788,48 +743,7 @@ def add_cors(response):
 # tick in real time even when the cycle wasn't user-triggered. Skips when
 # the broker is already running (a manual POST /api/scrape can race the
 # cron tick — manual wins; this thread quietly waits for the next slot).
-def _bg_scrape_loop() -> None:
-    log.info("Background scraper enabled — interval=%ds", FAST_INTERVAL)
-    # First tick gets a short delay so the Flask boot path isn't competing
-    # with the scraper for SQLite init/imports on cold starts.
-    time.sleep(15)
-    while True:
-        try:
-            if is_quiet_hours():
-                log.debug("BG scrape: quiet hours, skipping")
-            elif not broker.try_start("fast", _count_fast_companies()):
-                # Atomic check-and-arm: must mirror POST /api/scrape's gate
-                # exactly. A plain `if broker.is_running()` check would leave
-                # a race window where a manual POST wins the broker while
-                # we're about to call run_scrape() — both threads would then
-                # tick the same broker and double-scrape the same companies.
-                log.debug("BG scrape: broker busy, skipping cycle")
-            else:
-                log.info("BG scrape: starting fast cycle")
-                threading.Thread(
-                    target=_run_scrape_async,
-                    args=("fast",),
-                    daemon=True,
-                    name="bg-scrape-worker",
-                ).start()
-        except Exception:
-            # Never let the loop die — log and continue. The 10-min watchdog
-            # in StatusBroker.is_running() rescues us if a scrape crashed
-            # before its finally-finish() ran.
-            log.exception("BG scrape loop tick failed")
-        time.sleep(FAST_INTERVAL)
-
-
-def _should_run_bg_scraper() -> bool:
-    """Background loop is opt-out via DISABLE_BG_SCRAPE=1, and auto-disabled
-    under pytest so test_client() reloads don't spawn rogue threads that
-    write to the test DB."""
-    if "PYTEST_CURRENT_TEST" in os.environ or "pytest" in sys.modules:
-        return False
-    if os.environ.get("DISABLE_BG_SCRAPE", "").lower() in ("1", "true", "yes"):
-        return False
-    return os.environ.get("ENABLE_BG_SCRAPE", "1") == "1"
-
+# _bg_scrape_loop + _should_run_bg_scraper imported above from core.scrape_loop.
 
 # ─── Startup ──────────────────────────────────────────────────────
 init_db(DB_PATH)


### PR DESCRIPTION
PR 3 of 8 — server.py split (CLAUDE.md tech-debt #2). Moves all background-scraper machinery to a dedicated module.

## What moves

| Function | From `server.py` | To `core/scrape_loop.py` |
|---|---|---|
| `is_quiet_hours()` | line 77 | exported |
| `build_cache()` | line 89 | exported |
| `_count_fast_companies()` → `count_fast_companies()` | line 136 | exported |
| `_run_scrape_async()` → `run_scrape_async()` | line 144 | exported |
| `_bg_scrape_loop()` → `bg_scrape_loop()` | line 791 | exported |
| `_should_run_bg_scraper()` → `should_run_bg_scraper()` | line 823 | exported |

Underscore prefixes removed in the new module — they were module-private hints, no longer meaningful once the functions live in their own file.

`server.py` re-exports under the old `_name` aliases so the bodies of `/api/scrape`, `/api/scrape/status`, and the startup block don't have to change in this PR — those edits land with the route extractions in PRs 4–8.

## Why bundle them

All six are tightly coupled:
- `bg_scrape_loop` → `is_quiet_hours`, `count_fast_companies`, `run_scrape_async`
- `run_scrape_async` → `build_cache`
- `should_run_bg_scraper` is the gate for the loop
- `POST /api/scrape` also calls `run_scrape_async` (manual trigger)

Splitting them across files would either create a tangle or force `server.py` to keep four of them and the loop file to keep two — neither is clean. Together they are the "scraper system."

## Dependency graph (no cycles)

```
scrape_loop → core.state          (writes is_scraping, record_cycle, update_cache)
scrape_loop → core.config         (DB_PATH, FAST_INTERVAL)
scrape_loop → core.scrape_orchestrator  (run_scrape)
scrape_loop → core.scrape_status  (broker)
scrape_loop → config.companies    (COMPANIES for count_fast_companies)
scrape_loop → storage.db          (get_conn)

server          → core.scrape_loop  (re-exports the legacy aliases)
routes (future) → core.scrape_loop  (will import directly when their PRs land)
```

## Test plan

- [x] `pytest backend/tests/ -q` — 219 passed (unchanged)
- [x] BG scraper is auto-disabled under pytest, so the tests don't depend on it. `should_run_bg_scraper()` returns False when `PYTEST_CURRENT_TEST` is in env (preserved across the refactor)
- [ ] After deploy: Render logs show "Background scraper enabled — interval=300s" on startup (proves bg_scrape_loop is still launching from server.py's startup block)
- [ ] After deploy: first scrape cycle completes successfully (proves run_scrape_async still finds the DB + writes state correctly)

## Progress

```
✅ 1/8  core/config.py         (PR #60)
✅ 2/8  core/state.py          (PR #61)
✅ 3/8  core/scrape_loop.py    (this PR)
⏳ 4/8  routes/data_routes.py
⏳ 5/8  routes/scrape_routes.py
⏳ 6/8  routes/profile_routes.py
⏳ 7/8  routes/application_routes.py
⏳ 8/8  routes/resume_version_routes.py
```

server.py: 905 → 767 LOC (down 138 LOC across 3 PRs; halfway through the split).

https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr)_