### PR TITLE
refactor(server): extract read-only data routes (4/8)

### DIFF
--- a/backend/routes/data_routes.py
+++ b/backend/routes/data_routes.py
@@ -1,0 +1,80 @@
+"""Read-only data endpoints — extracted from server.py (4/8 server split).
+
+Five routes, all unauthenticated, all GET. Grouped here because they share
+a contract (no write side effects, no auth, served as the public read
+surface of the API):
+
+    GET /              — Self-describing root, auto-discovers app.url_map
+    GET /ping          — Keepalive (GitHub Actions / UptimeRobot hits this)
+    GET /api/data      — Full JSON cache for the dashboard
+    GET /api/health    — Uptime + cycle counters
+    GET /api/stats     — Quick DB stats
+
+The cache rebuild on /api/data cold-start is the only side effect, and
+it's idempotent.
+"""
+from flask import Blueprint, Response, current_app, jsonify
+
+from core.config import DB_PATH
+from core.scrape_loop import build_cache
+from core.state import state
+from storage.db import get_stats
+
+data_bp = Blueprint("data", __name__)
+
+
+@data_bp.route("/ping")
+def ping():
+    """Keepalive — GitHub Actions / UptimeRobot hits this every 14 min."""
+    return "ok", 200
+
+
+@data_bp.route("/api/data")
+def api_data():
+    """Full JSON export for dashboard."""
+    cached = state.get_cache()
+    if not cached:
+        build_cache()
+        cached = state.get_cache()
+    if cached:
+        return Response(cached, mimetype="application/json", headers={
+            "Access-Control-Allow-Origin": "*",
+            "Cache-Control": "public, max-age=60",
+        })
+    return jsonify({"error": "No data yet — first scrape in progress"}), 503
+
+
+@data_bp.route("/api/health")
+def api_health():
+    return jsonify(state.health()), 200, {"Access-Control-Allow-Origin": "*"}
+
+
+@data_bp.route("/api/stats")
+def api_stats():
+    try:
+        return jsonify(get_stats(DB_PATH)), 200, {"Access-Control-Allow-Origin": "*"}
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@data_bp.route("/")
+def index():
+    """Self-describing root. Auto-discovers routes from the live url_map
+    so this list never drifts when new blueprints register (PR #51
+    introduced this; we preserve it here)."""
+    # current_app vs the bare ``app`` we used in server.py: identical
+    # behavior inside a request, but works from a Blueprint without
+    # importing the app object back from server (which would create
+    # a circular import).
+    endpoints = sorted({
+        r.rule for r in current_app.url_map.iter_rules()
+        if not r.rule.startswith("/static")
+        and r.endpoint != "static"
+    })
+    return jsonify({
+        "service":   "JobScout API",
+        "version":   "3.1",
+        "endpoints": endpoints,
+        "endpoint_count": len(endpoints),
+        **state.health(),
+    }), 200, {"Access-Control-Allow-Origin": "*"}

--- a/backend/server.py
+++ b/backend/server.py
@@ -78,6 +78,10 @@ from routes.vault_routes import vault_bp
 app.register_blueprint(vault_bp)
 from routes.admin_routes import admin_bp
 app.register_blueprint(admin_bp)
+# Read-only data endpoints extracted to routes/data_routes.py (PR 4/8 of the
+# server.py split). Five routes: /, /ping, /api/data, /api/health, /api/stats.
+from routes.data_routes import data_bp
+app.register_blueprint(data_bp)
 
 
 # State + state singleton are imported above from core.state (PR 2/8).
@@ -85,42 +89,9 @@ app.register_blueprint(admin_bp)
 # one place at the top of the file rather than scattered through.
 
 # is_quiet_hours + build_cache imported above from core.scrape_loop (PR 3/8).
+# /ping, /api/data, /api/health, /api/stats, / extracted to routes/data_routes.py (PR 4/8).
 
-# ─── Flask routes ─────────────────────────────────────────────────
-
-@app.route("/ping")
-def ping():
-    """Keepalive — GitHub Actions / UptimeRobot hits this every 14 min."""
-    return "ok", 200
-
-
-@app.route("/api/data")
-def api_data():
-    """Full JSON export for dashboard."""
-    cached = state.get_cache()
-    if not cached:
-        build_cache()
-        cached = state.get_cache()
-    if cached:
-        return Response(cached, mimetype="application/json", headers={
-            "Access-Control-Allow-Origin": "*",
-            "Cache-Control": "public, max-age=60",
-        })
-    return jsonify({"error": "No data yet — first scrape in progress"}), 503
-
-
-@app.route("/api/health")
-def api_health():
-    return jsonify(state.health()), 200, {"Access-Control-Allow-Origin": "*"}
-
-
-@app.route("/api/stats")
-def api_stats():
-    try:
-        return jsonify(get_stats(DB_PATH)), 200, {"Access-Control-Allow-Origin": "*"}
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
-
+# ─── Flask routes (write/auth endpoints; data endpoints in Blueprint) ─
 
 # _count_fast_companies + _run_scrape_async imported above from core.scrape_loop.
 
@@ -702,24 +673,7 @@ def api_set_pin():
         return jsonify({"error": str(e)}), 500
 
 
-@app.route("/")
-def index():
-    # Auto-discover routes from app.url_map so this list never drifts when
-    # new blueprints are registered. Filter out static/internal Flask
-    # routes and keep the output stable across deploys (sorted).
-    endpoints = sorted({
-        r.rule for r in app.url_map.iter_rules()
-        if not r.rule.startswith("/static")
-        and r.endpoint != "static"
-    })
-    return jsonify({
-        "service":   "JobScout API",
-        "version":   "3.1",
-        "endpoints": endpoints,
-        "endpoint_count": len(endpoints),
-        **state.health(),
-    }), 200, {"Access-Control-Allow-Origin": "*"}
-
+# / (self-describing root) extracted to routes/data_routes.py (PR 4/8).
 
 # ─── CORS preflight ───────────────────────────────────────────────
 @app.after_request


### PR DESCRIPTION
PR 4 of 8 — server.py split.

Moves the 5 unauthenticated read-only endpoints to a dedicated Blueprint. They share a contract — no auth, no writes, public read surface — so they group naturally.

## Routes moved

| Route | Description |
|---|---|
| `GET /` | Self-describing root, auto-discovers `app.url_map` (preserves PR #51's dynamic listing) |
| `GET /ping` | Keepalive (GitHub Actions / UptimeRobot) |
| `GET /api/data` | Full JSON cache for dashboard |
| `GET /api/health` | Uptime + cycle counters |
| `GET /api/stats` | Quick DB stats |

## Subtle: `current_app` instead of `app` in `/`

The auto-discovering `/` route iterates `app.url_map.iter_rules()`. In the Blueprint version, we use `flask.current_app.url_map` — same behavior at runtime (it's the same Flask app object during a request), but it avoids having to circular-import the `app` instance back from `server.py`.

```python
endpoints = sorted({
    r.rule for r in current_app.url_map.iter_rules()
    if not r.rule.startswith("/static") and r.endpoint != "static"
})
```

## server.py change

- 5 inline route handlers removed (~50 LOC)
- 1 new import line: `from routes.data_routes import data_bp`
- 1 new register line: `app.register_blueprint(data_bp)`
- 721 LOC remaining (was 767)

## Test plan

- [x] `pytest backend/tests/ -q` — 219 passed (unchanged)
- [ ] After deploy: hit `/` → returns version 3.1 + dynamic endpoint list (regression on PR #51)
- [ ] After deploy: hit `/ping` → returns "ok"
- [ ] After deploy: hit `/api/health` → returns `total_cycles` and other state fields

## Progress

```
✅ 1/8  core/config.py         (PR #60)
✅ 2/8  core/state.py          (PR #61)
✅ 3/8  core/scrape_loop.py    (PR #62)
✅ 4/8  routes/data_routes.py  (this PR)
⏳ 5/8  routes/scrape_routes.py
⏳ 6/8  routes/profile_routes.py
⏳ 7/8  routes/application_routes.py
⏳ 8/8  routes/resume_version_routes.py
```

server.py: 905 → 721 LOC. Halfway through. Each remaining extraction follows the same pattern: Blueprint with the route bodies copy-pasted unchanged, imports adjusted to point at `core/*` modules, server.py drops the inline definitions.

https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr)_