### PR TITLE
refactor(server): extract scrape control routes (5/8)

### DIFF
--- a/backend/routes/scrape_routes.py
+++ b/backend/routes/scrape_routes.py
@@ -1,0 +1,77 @@
+"""Scrape control endpoints — extracted from server.py (5/8 server split).
+
+Two routes, both auth-gated when API_SECRET is set:
+
+    POST /api/scrape         — Manual trigger (returns 202 with live snapshot)
+    GET  /api/scrape/status  — Poll snapshot for the in-flight or last cycle
+
+Both use the StatusBroker for atomic check-and-arm so concurrent POSTs and
+the background loop can't double-trigger the same cycle.
+"""
+import logging
+import threading
+
+from flask import Blueprint, jsonify, request
+
+from core.config import check_api_secret
+# Import the module rather than the function so monkeypatch.setattr on
+# core.scrape_loop.run_scrape_async actually reaches us. (Tests that
+# stub the worker — see test_concurrent_scrape_requests — rely on this.)
+from core import scrape_loop
+from core.scrape_status import broker
+
+log = logging.getLogger("jobscout")
+
+scrape_bp = Blueprint("scrape", __name__)
+
+
+@scrape_bp.route("/api/scrape", methods=["POST", "OPTIONS"])
+def api_trigger_scrape():
+    """Trigger an immediate scrape in a background daemon thread.
+
+    Returns 202 with a status snapshot so the dashboard can poll
+    /api/scrape/status for live progress. A 409 is returned if a scrape is
+    already in flight (per the broker's 10-min watchdog).
+    """
+    if request.method == "OPTIONS":
+        return "", 204
+
+    if not check_api_secret(request):
+        return jsonify({"error": "unauthorized"}), 401
+
+    # Atomic check-and-arm: closes the race where two concurrent POSTs both
+    # pass is_running() and spawn two scrape threads. The broker is armed
+    # synchronously before we return 202, so the embedded snapshot already
+    # shows is_running=True — no false "scrape complete" on the first poll.
+    if not broker.try_start("fast", scrape_loop.count_fast_companies()):
+        return jsonify({
+            "started":  False,
+            "reason":   "scrape_in_progress",
+            "snapshot": broker.snapshot(),
+        }), 409
+
+    threading.Thread(
+        target=scrape_loop.run_scrape_async,
+        args=("fast",),
+        daemon=True,
+        name="scrape-worker",
+    ).start()
+
+    return jsonify({
+        "started":  True,
+        "snapshot": broker.snapshot(),
+    }), 202
+
+
+@scrape_bp.route("/api/scrape/status", methods=["GET"])
+def api_scrape_status():
+    """Live progress snapshot for the in-flight scrape (or last finished run).
+
+    Auth-gated symmetrically with POST /api/scrape: if API_SECRET is set, a
+    matching Bearer token is required. This prevents the snapshot leaking
+    cadence/company-name info to anonymous pollers in deployments that have
+    locked down the trigger.
+    """
+    if not check_api_secret(request):
+        return jsonify({"error": "unauthorized"}), 401
+    return jsonify(broker.snapshot()), 200, {"Access-Control-Allow-Origin": "*"}

--- a/backend/server.py
+++ b/backend/server.py
@@ -82,6 +82,10 @@ app.register_blueprint(admin_bp)
 # server.py split). Five routes: /, /ping, /api/data, /api/health, /api/stats.
 from routes.data_routes import data_bp
 app.register_blueprint(data_bp)
+# Scrape control endpoints extracted to routes/scrape_routes.py (PR 5/8).
+# POST /api/scrape, GET /api/scrape/status.
+from routes.scrape_routes import scrape_bp
+app.register_blueprint(scrape_bp)
 
 
 # State + state singleton are imported above from core.state (PR 2/8).
@@ -105,57 +109,7 @@ def _check_api_secret() -> bool:
     return check_api_secret(request)
 
 
-@app.route("/api/scrape", methods=["POST", "OPTIONS"])
-def api_trigger_scrape():
-    """Trigger an immediate scrape in a background daemon thread.
-
-    Returns 202 with a status snapshot so the dashboard can poll
-    /api/scrape/status for live progress. A 409 is returned if a scrape is
-    already in flight (per the broker's 10-min watchdog).
-    """
-    if request.method == "OPTIONS":
-        return "", 204
-
-    if not _check_api_secret():
-        return jsonify({"error": "unauthorized"}), 401
-
-    # Atomic check-and-arm: closes the race where two concurrent POSTs both
-    # pass is_running() and spawn two scrape threads. The broker is armed
-    # synchronously before we return 202, so the embedded snapshot already
-    # shows is_running=True — no false "scrape complete" on the first poll.
-    if not broker.try_start("fast", _count_fast_companies()):
-        return jsonify({
-            "started":  False,
-            "reason":   "scrape_in_progress",
-            "snapshot": broker.snapshot(),
-        }), 409
-
-    threading.Thread(
-        target=_run_scrape_async,
-        args=("fast",),
-        daemon=True,
-        name="scrape-worker",
-    ).start()
-
-    return jsonify({
-        "started":  True,
-        "snapshot": broker.snapshot(),
-    }), 202
-
-
-@app.route("/api/scrape/status", methods=["GET"])
-def api_scrape_status():
-    """Live progress snapshot for the in-flight scrape (or last finished run).
-
-    Auth-gated symmetrically with POST /api/scrape: if API_SECRET is set, a
-    matching Bearer token is required. This prevents the snapshot leaking
-    cadence/company-name info to anonymous pollers in deployments that have
-    locked down the trigger.
-    """
-    if not _check_api_secret():
-        return jsonify({"error": "unauthorized"}), 401
-    return jsonify(broker.snapshot()), 200, {"Access-Control-Allow-Origin": "*"}
-
+# /api/scrape, /api/scrape/status extracted to routes/scrape_routes.py (PR 5/8).
 
 # ─── Profile & Resume endpoints ────────────────────────────────────
 

--- a/backend/tests/test_scrape_status.py
+++ b/backend/tests/test_scrape_status.py
@@ -226,6 +226,15 @@ def test_concurrent_scrape_requests(tmp_path, monkeypatch):
         release.wait(timeout=3)
         b.finish({"new": 0})
 
+    # Patch where the function lives now (core.scrape_loop) — after the
+    # server.py split (PR #62, #64), the /api/scrape Blueprint imports
+    # run_scrape_async directly from core.scrape_loop instead of going
+    # through server. Patching `server._run_scrape_async` would only
+    # affect the legacy re-export, not the live call site.
+    import core.scrape_loop as _scrape_loop
+    monkeypatch.setattr(_scrape_loop, "run_scrape_async", _slow_worker)
+    # Keep the legacy alias mutation too in case any other call path
+    # still goes through server (defense in depth — cheap).
     monkeypatch.setattr(server, "_run_scrape_async", _slow_worker)
 
     c = server.app.test_client()


### PR DESCRIPTION
PR 5 of 8 — server.py split.

Moves `/api/scrape` and `/api/scrape/status` to their own Blueprint. Both are auth-gated through `check_api_secret(request)` (the `core/config` helper that reads env live, from PR #60).

## One important detail: lazy function lookup

The Blueprint imports the **module**, not the function:

```python
from core import scrape_loop   # module
# ...
threading.Thread(target=scrape_loop.run_scrape_async, ...).start()
```

Why this matters: `monkeypatch.setattr(core.scrape_loop, "run_scrape_async", stub)` rebinds the attribute on the source module. If we'd written `from core.scrape_loop import run_scrape_async`, the route would capture the function at import time and the test patch would silently miss us. The existing `test_concurrent_scrape_requests` test relies on stubbing the worker to keep itself hermetic — without this idiom, every CI run would actually try to scrape Anthropic, Stripe, etc., hit 403s, and either pass spuriously or fail confusingly.

Documented in a comment in the route file so the next person to "clean up" the imports knows why.

## Test fix

`test_scrape_status.py:test_concurrent_scrape_requests` was patching `server._run_scrape_async`. After this split, the live call site is `core.scrape_loop.run_scrape_async`, so I patch both locations (defense in depth — the legacy alias still works via the re-export, but new tests should target the real home). Existing assertion + flow unchanged.

## server.py change

- 2 route handlers removed (~55 LOC)
- 1 import + register line added
- 721 → 675 LOC

## Test plan

- [x] `pytest backend/tests/ -q` — 219 passed (unchanged)
- [x] `test_concurrent_scrape_requests` specifically — confirms broker still gates correctly via 202/409 flow
- [ ] After deploy: `curl -X POST /api/scrape` with the right Bearer token returns 202 with snapshot
- [ ] After deploy: concurrent POSTs from the BG loop + manual click → only one wins, the other gets 409

## Progress

```
✅ 1/8  core/config.py            (PR #60)
✅ 2/8  core/state.py             (PR #61)
✅ 3/8  core/scrape_loop.py       (PR #62)
✅ 4/8  routes/data_routes.py     (PR #63)
✅ 5/8  routes/scrape_routes.py   (this PR)
⏳ 6/8  routes/profile_routes.py        — 4 routes
⏳ 7/8  routes/application_routes.py    — 6 routes
⏳ 8/8  routes/resume_version_routes.py — 5 routes
```

server.py: 905 → 675 LOC. 230 LOC pulled out over 5 PRs.

https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr)_