### PR TITLE
Add bulk resume upload tool and improve filename parsing

### DIFF
--- a/backend/routes/vault_routes.py
+++ b/backend/routes/vault_routes.py
@@ -188,6 +188,7 @@ def vault_upload():
         company = request.form.get("company", "").strip()
         role = request.form.get("role", "").strip() or None
         filename = pdf_file.filename
+        submitted_at = request.form.get("submitted_at", "").strip() or None
     else:
         data = request.get_json(force=True)
         b64 = data.get("pdf_base64", "")
@@ -200,9 +201,28 @@ def vault_upload():
         company = data.get("company", "").strip()
         role = data.get("role", "").strip() or None
         filename = data.get("filename", "")
+        submitted_at = (data.get("submitted_at") or "").strip() or None
 
     if not company:
         return jsonify({"error": "company is required"}), 400
+
+    # Validate submitted_at: must be ISO 8601, year >= 2000, not in the
+    # future (allow 1 day of clock skew). list_vault() returns this as
+    # modified_at; bad values would pollute the dashboard's sort order.
+    if submitted_at is not None:
+        from datetime import datetime, timezone, timedelta
+        try:
+            dt = datetime.fromisoformat(submitted_at.replace("Z", "+00:00"))
+        except ValueError:
+            return jsonify({"error": f"submitted_at must be ISO 8601 (got {submitted_at!r})"}), 400
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
+        if dt > now + timedelta(days=1):
+            return jsonify({"error": f"submitted_at is in the future: {submitted_at}"}), 400
+        if dt < datetime(2000, 1, 1, tzinfo=timezone.utc):
+            return jsonify({"error": f"submitted_at is before 2000: {submitted_at}"}), 400
+        submitted_at = dt.isoformat()
 
     # Issue #35: length cap before the path is built. canonical_filename also
     # sanitizes, but capping at the route layer gives a clearer error and
@@ -232,6 +252,7 @@ def vault_upload():
             role=role,
             original_filename=filename,
             db_path=DB_PATH,
+            submitted_at=submitted_at,
         )
     except ValueError as e:
         # canonical_filename rejects fully-sanitized-to-empty names, and

--- a/backend/storage/company_rules.py
+++ b/backend/storage/company_rules.py
@@ -1,0 +1,127 @@
+"""Canonical company + role tagging rules for resume filenames.
+
+Single source of truth for ``parse_resume_filename`` in
+``backend/storage/resume_vault.py``. Imports are one-way:
+``resume_vault`` consumes from here; nothing here imports from there.
+
+Two-way bridge with the AutoApply AI tag builder
+(``backend/app/services/resume_generator.py`` in the separate
+``autoapply-ai`` repo). That builder goes
+``(name, company, role_title, job_id) → "Narendranath_GS_DE_JOB123"``;
+JobScout's parser goes the inverse direction. The canonical short-name
+and role-abbreviation maps below are the union of:
+
+* JobScout's pre-existing legacy aliases (e.g. ``"data" → Data Engineer``,
+  ``"bofa" → Bank of America``)
+* AutoApply's canonical ``_COMPANY_SHORT`` and ``_ROLE_ABBREVS`` tables
+
+For each key the lowercase form is canonical; lookups in the parser
+``.lower()`` the input before matching. JobID handling (the optional
+``_{JobID}`` segment of the AutoApply grammar) is in ``JOB_ID_RE`` below.
+
+Known cross-system asymmetry (called out in the AutoApply notes):
+
+* ``_company_matches`` in AutoApply's retrieval agent computes initials
+  by splitting on whitespace only, so ``"JP Morgan Chase"`` → ``"jmc"``.
+* This module — and the AutoApply tag builder — treat ``"JPMC"`` as the
+  canonical short name. Retrieval is permissive (it accepts ``"jmc"`` or
+  ``"jpmc"``); tag-building is canonical (only ``"JPMC"``). This file
+  takes the canonical side.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ── Company short-name → canonical display name ──────────────────────────
+# Keys are lowercase. Order doesn't matter — lookup is by exact key.
+COMPANY_ALIASES: dict[str, str] = {
+    # Finance
+    "gs": "Goldman Sachs", "gsjc": "Goldman Sachs",
+    "jpmc": "JPMorgan Chase", "jpmorgan": "JPMorgan Chase",
+    "bofa": "Bank of America", "bankofamerica": "Bank of America",
+    "ms": "Morgan Stanley", "morganstanley": "Morgan Stanley",
+    "aexp": "American Express", "americanexpress": "American Express",
+    "capitalone": "Capital One", "capital_one": "Capital One",
+    "wellsfargo": "Wells Fargo",
+    # Big tech — JobScout legacy
+    "meta": "Meta", "facebook": "Meta",
+    "disney": "Disney", "walt_disney": "Disney",
+    "sf": "Salesforce", "salesforce": "Salesforce",
+    # Big tech — added from AutoApply _COMPANY_SHORT
+    "msft": "Microsoft", "microsoft": "Microsoft",
+    "amzn": "Amazon", "amazon": "Amazon",
+    "nflx": "Netflix", "netflix": "Netflix",
+    "google": "Google", "alphabet": "Google",
+    # Misc
+    "qt": "Quantitative Trading",
+    "sams": "Sam's Club",
+    "at&t": "AT&T", "att": "AT&T",
+    "ibm": "IBM", "ea": "Electronic Arts",
+    "cvs": "CVS Health",
+}
+
+# ── Role abbreviation → canonical role name ─────────────────────────────
+# Keys are lowercase. AutoApply's substring-match table is inverted here:
+# we key on the canonical abbreviation (DE, MLE, …) and on legacy long
+# forms (data, ml, …) so both legacy and AutoApply filenames parse.
+ROLE_ALIASES: dict[str, str] = {
+    # JobScout legacy
+    "de": "Data Engineer", "data": "Data Engineer",
+    "ml": "ML Engineer", "ai": "AI Engineer",
+    "sde": "Software Engineer", "se": "Software Engineer",
+    "be": "Backend Engineer",
+    "ds": "Data Scientist", "dq": "Data Quality",
+    "ae": "Analytics Engineer",
+    "quant": "Quant Strategist", "aiq": "AI Quant",
+    # AutoApply canonical abbrevs
+    "swe": "Software Engineer",
+    "mle": "ML Engineer",
+    "da": "Data Analyst",
+    "pe": "Platform Engineer",
+    "pm": "Product Manager",
+    "sa": "Solutions Architect",
+    "sre": "Site Reliability Engineer",
+    "as": "Applied Scientist",
+}
+
+# ── Multi-word companies that appear as consecutive filename tokens ──────
+# Tuple of lowercased parts → canonical display name. ``None`` means
+# "don't merge — let downstream logic pick the trailing word(s) up as
+# role" (used for "goldman_sachs_ai" → company=Goldman Sachs, role=AI).
+MULTI_WORD_COMPANIES: dict[tuple[str, ...], str | None] = {
+    ("goldman", "sachs"): "Goldman Sachs",
+    ("capital", "one"): "Capital One",
+    ("bank", "of", "america"): "Bank of America",
+    ("morgan", "stanley"): "Morgan Stanley",
+    ("american", "express"): "American Express",
+    ("wells", "fargo"): "Wells Fargo",
+    ("walt", "disney"): "Disney",
+    # AutoApply expanded forms
+    ("jp", "morgan"): "JPMorgan Chase",
+    ("jp", "morgan", "chase"): "JPMorgan Chase",
+    ("meta", "platforms"): "Meta",
+    # 3-word disambiguation — let trailing word fall through to role
+    ("goldman", "sachs", "ai"): None,
+}
+
+# ── JobID detection ─────────────────────────────────────────────────────
+# AutoApply grammar: ``{FirstName}_{CompanyShort}_{RoleAbbrev}[_{JobID}]``
+# JobID examples seen: JOB123, JOB456, REQ12345. Pattern: uppercase
+# letters and digits, length ≥ 3, must contain at least one digit (so
+# "DE" doesn't accidentally match). Parser only treats the LAST token as
+# a JobID when there are ≥ 2 role-segment tokens — otherwise we'd
+# misclassify a single-token alphanumeric role.
+JOB_ID_RE = re.compile(r"^[A-Z][A-Z0-9]*\d[A-Z0-9]*$|^\d{3,}$")
+
+
+def is_job_id(token: str) -> bool:
+    """True if ``token`` looks like an AutoApply JobID segment.
+
+    Conservative — must be all-uppercase-or-digit and contain at least
+    one digit. ``"DE"`` → False; ``"JOB123"`` → True; ``"REQ12345"`` →
+    True; ``"12345"`` → True.
+    """
+    if not token:
+        return False
+    return bool(JOB_ID_RE.match(token))

--- a/backend/storage/db.py
+++ b/backend/storage/db.py
@@ -373,9 +373,17 @@ def upsert_resume_version(
     target_roles: list = None,
     target_companies: list = None,
     notes: str = "",
+    submitted_at: str | None = None,
 ) -> str:
-    """Insert or update a resume version. Returns 'new' or 'updated'."""
+    """Insert or update a resume version. Returns 'new' or 'updated'.
+
+    When ``submitted_at`` (ISO 8601 string) is provided it is used as the
+    row's ``updated_at`` value — and on INSERT also as ``created_at``.
+    This lets bulk-imports preserve the original application date
+    instead of stamping every row with the import moment.
+    """
     now = datetime.now(timezone.utc).isoformat()
+    ts = submitted_at or now
     skills = skills or []
     target_roles = target_roles or []
     target_companies = target_companies or []
@@ -393,7 +401,7 @@ def upsert_resume_version(
         """, (
             version_key, display_name, resume_text,
             json.dumps(skills), json.dumps(target_roles), json.dumps(target_companies),
-            notes, now, now,
+            notes, ts, ts,
         ))
         return "new"
     else:
@@ -405,7 +413,7 @@ def upsert_resume_version(
         """, (
             display_name, resume_text,
             json.dumps(skills), json.dumps(target_roles), json.dumps(target_companies),
-            notes, now, version_key,
+            notes, ts, version_key,
         ))
         return "updated"
 

--- a/backend/storage/resume_vault.py
+++ b/backend/storage/resume_vault.py
@@ -55,34 +55,15 @@ def _ensure_vault():
 #  NAMING CONVENTION PARSER
 # ═══════════════════════════════════════════════════════════════════
 
-# Company alias map (your filenames → canonical names)
-COMPANY_ALIASES = {
-    "gs": "Goldman Sachs", "gsjc": "Goldman Sachs",
-    "jpmc": "JPMorgan Chase", "jpmorgan": "JPMorgan Chase",
-    "bofa": "Bank of America", "bankofamerica": "Bank of America",
-    "ms": "Morgan Stanley", "morganstanley": "Morgan Stanley",
-    "aexp": "American Express", "americanexpress": "American Express",
-    "capitalone": "Capital One", "capital_one": "Capital One",
-    "wellsfargo": "Wells Fargo",
-    "meta": "Meta", "facebook": "Meta",
-    "disney": "Disney", "walt_disney": "Disney",
-    "sf": "Salesforce", "salesforce": "Salesforce",
-    "qt": "Quantitative Trading",
-    "sams": "Sam's Club",
-    "at&t": "AT&T", "att": "AT&T",
-    "ibm": "IBM", "ea": "Electronic Arts",
-    "cvs": "CVS Health",
-}
-
-# Role alias map (filename suffixes → canonical role names)
-ROLE_ALIASES = {
-    "de": "Data Engineer", "data": "Data Engineer",
-    "ml": "ML Engineer", "ai": "AI Engineer",
-    "sde": "Software Engineer", "se": "Software Engineer", "be": "Backend Engineer",
-    "ds": "Data Scientist", "dq": "Data Quality",
-    "ae": "Analytics Engineer",
-    "quant": "Quant Strategist", "aiq": "AI Quant",
-}
+# Canonical alias source. The dicts live in company_rules.py so they can
+# be edited without touching parser logic, and so the AutoApply repo's
+# canonical maps and JobScout's legacy maps stay merged in one place.
+from storage.company_rules import (
+    COMPANY_ALIASES,
+    ROLE_ALIASES,
+    MULTI_WORD_COMPANIES,
+    is_job_id,
+)
 
 
 def parse_resume_filename(filename: str) -> dict:
@@ -133,30 +114,40 @@ def parse_resume_filename(filename: str) -> dict:
         parts = ["unknown"]
 
     # ─── Multi-word company detection ────────────────────
-    # Known multi-word companies that appear as consecutive parts
-    MULTI_WORD = {
-        ("goldman", "sachs"): "Goldman Sachs",
-        ("capital", "one"): "Capital One",
-        ("bank", "of", "america"): "Bank of America",
-        ("morgan", "stanley"): "Morgan Stanley",
-        ("american", "express"): "American Express",
-        ("wells", "fargo"): "Wells Fargo",
-        ("walt", "disney"): "Disney",
-        ("goldman", "sachs", "ai"): None,  # don't merge 3-word, let role pick up "ai"
-    }
-
+    # Canonical table lives in company_rules.MULTI_WORD_COMPANIES.
     company_parts = []
     role_parts = []
     company_done = False
+    # ``multi_word_hit`` is True when the company name came from the
+    # canonical multi-word table — in that case the value is already
+    # the final display name and the alias / title-case pass below must
+    # not re-touch it (else "JPMorgan Chase" becomes "Jpmorgan Chase").
+    multi_word_hit = False
     i = 0
 
-    # Check for 2-word company match at start
-    if len(parts) >= 2:
+    # Check for 3-word and 2-word company match at start; longest first
+    # so ("jp","morgan","chase") wins over ("jp","morgan").
+    if not company_done and len(parts) >= 3:
+        three = (parts[0].lower(), parts[1].lower(), parts[2].lower())
+        if three in MULTI_WORD_COMPANIES:
+            merged = MULTI_WORD_COMPANIES[three]
+            if merged is not None:
+                company_parts = [merged]
+                i = 3
+                company_done = True
+                multi_word_hit = True
+            # When merged is None (e.g. ("goldman","sachs","ai")) we
+            # deliberately fall through so the 2-word match below picks
+            # up the company and the trailing word becomes the role.
+    if not company_done and len(parts) >= 2:
         two = (parts[0].lower(), parts[1].lower())
-        if two in MULTI_WORD:
-            company_parts = [MULTI_WORD[two]]
-            i = 2
-            company_done = True
+        if two in MULTI_WORD_COMPANIES:
+            merged = MULTI_WORD_COMPANIES[two]
+            if merged is not None:
+                company_parts = [merged]
+                i = 2
+                company_done = True
+                multi_word_hit = True
 
     if not company_done:
         # Naren_ prefix: first part is role if it's a known role abbreviation
@@ -177,13 +168,29 @@ def parse_resume_filename(filename: str) -> dict:
     if i < len(parts):
         role_parts.extend(parts[i:])
 
+    # ─── Peel off trailing JobID (AutoApply grammar) ─────
+    # AutoApply tags can end in ``_{JobID}`` (e.g. ``..._DE_JOB123``).
+    # Only treat the LAST role token as a JobID when there are at least
+    # two role tokens — otherwise a single-token alphanumeric role
+    # (e.g. ``..._R2D2``) would lose its only segment. Conservative
+    # ``is_job_id`` requires uppercase + at least one digit.
+    job_id = None
+    if len(role_parts) >= 2 and is_job_id(role_parts[-1]):
+        job_id = role_parts[-1]
+        role_parts = role_parts[:-1]
+
     # ─── Resolve aliases ─────────────────────────────────
     company_raw = "_".join(company_parts)
     role_raw = "_".join(role_parts) if role_parts else None
 
-    # Company alias (check both original and lowered)
+    # Company alias (check both original and lowered). When the
+    # multi-word table already produced a canonical name, use it
+    # verbatim — title-casing would mangle mixed-case names like
+    # "JPMorgan Chase".
     company = company_raw
-    if company_raw.lower() in COMPANY_ALIASES:
+    if multi_word_hit:
+        company = company_parts[0]
+    elif company_raw.lower() in COMPANY_ALIASES:
         company = COMPANY_ALIASES[company_raw.lower()]
     elif len(company_parts) == 1:
         company = COMPANY_ALIASES.get(company_parts[0].lower(), company_raw.replace("_", " ").title())
@@ -212,6 +219,7 @@ def parse_resume_filename(filename: str) -> dict:
         "version_key": version_key,
         "display_name": display_name,
         "extension": ext,
+        "job_id": job_id,
     }
 
 

--- a/backend/storage/resume_vault.py
+++ b/backend/storage/resume_vault.py
@@ -92,18 +92,59 @@ def parse_resume_filename(filename: str) -> dict:
     ext = Path(filename).suffix.lower()
 
     # Normalize: remove common prefixes
+    # ─── Strip the leading name prefix ───────────────────
+    # Longest-prefix-wins. Entries that *don't* end in an underscore
+    # also match the "glued" form (NarendranathGS, NarenDE), but only
+    # when there's content after them — otherwise ``Naren.pdf`` would
+    # collapse to "unknown".
+    # ``used_naren_prefix`` flags the Naren-family forms: when a Naren
+    # prefix matches, the next token is treated as a role abbreviation
+    # (role-first pattern), e.g. ``Naren_DE_affirm`` → role=DE,
+    # company=Affirm; ``NarenML.pdf`` → role-only template.
+    _NAME_PREFIXES = sorted(
+        [
+            ("Narendranath_Edara_", False),
+            ("Edara_Narendranath_", False),
+            ("Edara_NarendraNath_", False),
+            ("EdaraNarendranath", False),
+            ("NarendranathEdara", False),
+            ("ENarendranath_", False),
+            ("ENarendranath", False),
+            ("NarendranathE_", False),
+            ("Narendranath_", False),
+            ("NarendraNath_", False),
+            ("Narendranath", False),    # glued: NarendranathGS, NarendranathE
+            ("Narendra_", False),
+            ("Narendra", False),         # glued: NarendraN
+            ("Naren_", True),            # role-first: Naren_DE_affirm
+            ("Naren", True),             # role-first glued: NarenDE, NarenML
+            ("Resume_", False),
+        ],
+        key=lambda p: -len(p[0]),
+    )
+
     clean = stem
-    used_naren_prefix = False  # Naren_ has role-first pattern
-    for prefix in ["Narendranath_Edara_", "Narendranath_", "NarendranathE_",
-                    "NarenML_", "Narendra_", "Resume_"]:
-        if clean.startswith(prefix):
-            clean = clean[len(prefix):]
-            break
-    else:
-        # Check Naren_ separately (role-first: Naren_DE_affirm)
-        if clean.startswith("Naren_"):
-            clean = clean[len("Naren_"):]
-            used_naren_prefix = True
+    used_naren_prefix = False
+    for prefix, is_naren in _NAME_PREFIXES:
+        if not clean.startswith(prefix):
+            continue
+        rest = clean[len(prefix):]
+        # Glued (no-trailing-underscore) prefixes only fire when the
+        # remainder *looks like a tag*, not a continuation of the name.
+        # Two guards:
+        #   1. must have content after the prefix; and
+        #   2. that content must start with an uppercase letter or
+        #      digit — so ``NarendranathGS`` strips ("GS" starts upper),
+        #      but ``Narendra`` matched against ``Narendranath`` (rest
+        #      = "nath") and ``Narendranath`` matched against
+        #      ``Narendranath Edara_…`` (rest = " Edara…") do not.
+        if not prefix.endswith("_"):
+            stripped = rest.lstrip("_-")
+            if not stripped or not stripped[0].isalnum() or not stripped[0].isupper() and not stripped[0].isdigit():
+                continue
+        clean = rest.lstrip("_-")
+        used_naren_prefix = is_naren
+        break
 
     # Split on underscores
     parts = [p.strip() for p in clean.split("_") if p.strip()]
@@ -150,15 +191,32 @@ def parse_resume_filename(filename: str) -> dict:
                 multi_word_hit = True
 
     if not company_done:
-        # Naren_ prefix: first part is role if it's a known role abbreviation
-        if used_naren_prefix and len(parts) >= 2 and parts[0].lower() in ROLE_ALIASES:
-            role_parts = [parts[0]]
-            company_parts = [parts[1]]
-            i = 2
-            company_done = True
-            # Remaining parts go to role
-            role_parts.extend(parts[i:])
-            i = len(parts)
+        # Naren-family prefix: first part is a role abbreviation.
+        if used_naren_prefix and parts[0].lower() in ROLE_ALIASES:
+            if len(parts) == 1:
+                # Role-only template — Naren_DE.pdf, NarenML.pdf, etc.
+                # There's no company tag in the filename, so the file
+                # represents the generic version of that role. Tag the
+                # company as "Standard" so all role templates land in a
+                # single predictable bucket in the vault.
+                # multi_word_hit short-circuits the alias / title-case
+                # pass below so the literal string "Standard" is kept.
+                company_parts = ["Standard"]
+                role_parts = [parts[0]]
+                i = 1
+                company_done = True
+                multi_word_hit = True
+            else:
+                # Existing role-first form: Naren_DE_affirm → role=DE,
+                # company=Affirm. Anything after position 1 trails into
+                # the role (Naren_DE_Cap_One could in principle yield
+                # role=DE, company=Cap_One; that's an edge case).
+                role_parts = [parts[0]]
+                company_parts = [parts[1]]
+                i = 2
+                company_done = True
+                role_parts.extend(parts[i:])
+                i = len(parts)
         else:
             company_parts = [parts[0]]
             i = 1
@@ -169,13 +227,16 @@ def parse_resume_filename(filename: str) -> dict:
         role_parts.extend(parts[i:])
 
     # ─── Peel off trailing JobID (AutoApply grammar) ─────
-    # AutoApply tags can end in ``_{JobID}`` (e.g. ``..._DE_JOB123``).
-    # Only treat the LAST role token as a JobID when there are at least
-    # two role tokens — otherwise a single-token alphanumeric role
-    # (e.g. ``..._R2D2``) would lose its only segment. Conservative
-    # ``is_job_id`` requires uppercase + at least one digit.
+    # AutoApply tags can end in ``_{JobID}`` (e.g. ``..._DE_JOB123``)
+    # and Workday-saved files end in ``_YYYYMMDD``. Both should land in
+    # ``job_id`` rather than being mis-tagged as the role.
+    # ``is_job_id`` is conservative — requires uppercase + a digit (so
+    # role tokens like DE, SWE, AI never match) or all-digits length≥3.
+    # That conservativeness is what lets us peel off even a single-token
+    # role_parts (e.g. ``Narendranath_MS_240`` → company=Morgan Stanley,
+    # role=None, job_id=240).
     job_id = None
-    if len(role_parts) >= 2 and is_job_id(role_parts[-1]):
+    if role_parts and is_job_id(role_parts[-1]):
         job_id = role_parts[-1]
         role_parts = role_parts[:-1]
 

--- a/backend/storage/resume_vault.py
+++ b/backend/storage/resume_vault.py
@@ -412,6 +412,7 @@ def save_pdf_to_vault(
     role: str = None,
     original_filename: str = None,
     db_path: str = None,
+    submitted_at: str = None,
 ) -> dict:
     """
     Save a PDF to the local vault + extract text + register in DB.
@@ -482,6 +483,19 @@ def save_pdf_to_vault(
     with open(text_path, "w", encoding="utf-8") as f:
         f.write(text)
 
+    # Stamp the filesystem mtime to the original submission date when
+    # the caller supplied one. ``list_vault`` returns ``modified_at``
+    # straight from ``stat().st_mtime``, so this is what the dashboard
+    # surfaces as the resume's date. Done after both writes (PDF + text)
+    # so the order of writes can't perturb the timestamp.
+    if submitted_at:
+        try:
+            ts = datetime.fromisoformat(submitted_at.replace("Z", "+00:00")).timestamp()
+            os.utime(vault_path, (ts, ts))
+            os.utime(text_path, (ts, ts))
+        except (ValueError, OSError) as e:
+            log.warning("Failed to apply submitted_at=%r: %s", submitted_at, e)
+
     # Extract skills
     from storage.profile_manager import extract_skills_from_resume
     skills = extract_skills_from_resume(text)
@@ -499,6 +513,7 @@ def save_pdf_to_vault(
             target_roles=[role] if role else [],
             target_companies=[company],
             notes=f"Uploaded from: {original_filename or fname}",
+            submitted_at=submitted_at,
         )
         conn.commit()
         conn.close()

--- a/backend/tools/bulk_upload_to_render.py
+++ b/backend/tools/bulk_upload_to_render.py
@@ -26,11 +26,19 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import sys
 import time
 from pathlib import Path
 
 import requests
+
+# Recommended exclude regex for the bulk of "noise" files in
+# C:\Users\naren\OneDrive\Desktop\Resume Easy. Surfaced via --help; not
+# applied by default so this stays a generic tool.
+RECOMMENDED_EXCLUDE = (
+    r"(?i)^(?:jayanth|lankipalli|naru_kiran|sai_maruthi|siva\s+chandan)"
+)
 
 # Make ``storage.resume_vault`` importable when run as a script.
 _HERE = Path(__file__).resolve().parent
@@ -140,6 +148,16 @@ def main(argv: list[str] | None = None) -> int:
     )
     p.add_argument("--limit", type=int, default=0, help="Stop after N successful uploads.")
     p.add_argument("--timeout", type=float, default=60.0, help="Per-request timeout (seconds).")
+    p.add_argument(
+        "--exclude",
+        default="",
+        help=(
+            "Regex matched (case-insensitive, via .search) against each "
+            "filename; matches are skipped. Recommended for the "
+            "Resume Easy folder: "
+            + RECOMMENDED_EXCLUDE
+        ),
+    )
     args = p.parse_args(argv)
 
     if not args.api_url:
@@ -155,6 +173,14 @@ def main(argv: list[str] | None = None) -> int:
     exts = list(DEFAULT_EXTENSIONS)
     if args.include_docx:
         exts.append(".docx")
+
+    exclude_re = None
+    if args.exclude:
+        try:
+            exclude_re = re.compile(args.exclude)
+        except re.error as e:
+            print(f"ERROR: bad --exclude regex: {e}", file=sys.stderr)
+            return 2
 
     candidates = sorted(
         f for f in src.rglob("*")
@@ -173,9 +199,15 @@ def main(argv: list[str] | None = None) -> int:
     skipped_existing = 0
     skipped_oversize = 0
     skipped_unparseable = 0
+    skipped_excluded = 0
     failed: list[tuple[str, str]] = []
 
     for pdf_path in candidates:
+        if exclude_re and exclude_re.search(pdf_path.name):
+            if args.dry_run:
+                print(f"  - {pdf_path.name}: skip (--exclude match)")
+            skipped_excluded += 1
+            continue
         meta = parse_resume_filename(pdf_path.name)
         company = _truncate(meta.get("company"), MAX_FIELD_LEN)
         role = _truncate(meta.get("role"), MAX_FIELD_LEN)
@@ -227,6 +259,7 @@ def main(argv: list[str] | None = None) -> int:
     print(f"  skipped (existing): {skipped_existing}")
     print(f"  skipped (oversize): {skipped_oversize}")
     print(f"  skipped (parse):    {skipped_unparseable}")
+    print(f"  skipped (exclude):  {skipped_excluded}")
     print(f"  failed:             {len(failed)}")
     for name, msg in failed:
         print(f"    - {name}: {msg}")

--- a/backend/tools/bulk_upload_to_render.py
+++ b/backend/tools/bulk_upload_to_render.py
@@ -29,6 +29,7 @@ import os
 import re
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 import requests
@@ -80,6 +81,7 @@ def _upload_one(
     company: str,
     role: str | None,
     timeout: float,
+    submitted_at: str | None = None,
 ) -> tuple[bool, str]:
     """POST one PDF. Returns (ok, message). Retries on transient errors."""
     headers = {"Authorization": f"Bearer {secret}"} if secret else {}
@@ -93,6 +95,8 @@ def _upload_one(
                 data = {"company": company}
                 if role:
                     data["role"] = role
+                if submitted_at:
+                    data["submitted_at"] = submitted_at
                 resp = requests.post(
                     f"{api_url}/api/vault/upload",
                     headers=headers,
@@ -219,7 +223,9 @@ def main(argv: list[str] | None = None) -> int:
             continue
 
         try:
-            size = pdf_path.stat().st_size
+            st = pdf_path.stat()
+            size = st.st_size
+            submitted_at = datetime.fromtimestamp(st.st_mtime, timezone.utc).isoformat()
         except OSError as e:
             print(f"  - {pdf_path.name}: stat failed ({e})")
             failed.append((pdf_path.name, f"stat: {e}"))
@@ -233,7 +239,8 @@ def main(argv: list[str] | None = None) -> int:
             skipped_existing += 1
             continue
 
-        plan = f"{company}" + (f" / {role}" if role else "") + f"  [{vk}]"
+        date_str = submitted_at[:10]
+        plan = f"{company}" + (f" / {role}" if role else "") + f"  [{vk}]  ({date_str})"
         if args.dry_run:
             print(f"  · {pdf_path.name} -> {plan}  (dry-run)")
             uploaded += 1
@@ -241,7 +248,10 @@ def main(argv: list[str] | None = None) -> int:
                 break
             continue
 
-        ok, msg = _upload_one(api_url, args.api_secret or None, pdf_path, company, role, args.timeout)
+        ok, msg = _upload_one(
+            api_url, args.api_secret or None, pdf_path, company, role, args.timeout,
+            submitted_at=submitted_at,
+        )
         marker = "+" if ok else "x"
         print(f"  {marker} {pdf_path.name} -> {plan}  {msg}")
         if ok:

--- a/backend/tools/bulk_upload_to_render.py
+++ b/backend/tools/bulk_upload_to_render.py
@@ -1,0 +1,237 @@
+"""Bulk-upload local PDF resumes to the live JobScout vault on Render.
+
+Run this from your laptop (NOT inside the Render container) to walk a local
+folder of PDFs and POST each one to ``/api/vault/upload``. Filenames are
+parsed with the same ``parse_resume_filename`` logic the server uses, so
+``Narendranath_GS_data.pdf`` is registered as ``Goldman Sachs / Data Engineer``.
+
+Usage (PowerShell):
+
+    cd job-scout\\backend
+    $env:JOBSCOUT_API_URL = "https://your-app.onrender.com"
+    $env:JOBSCOUT_API_SECRET = "your_secret"
+    python -m tools.bulk_upload_to_render `
+        --source-dir "C:\\Users\\naren\\OneDrive\\Desktop\\Resume Easy"
+
+Flags:
+    --dry-run            Parse + plan only, send nothing.
+    --no-skip-existing   Upload even if the version_key already exists in
+                         the vault (server will overwrite metadata).
+    --include-docx       Also try .docx; expect server rejection since
+                         /api/vault/upload validates PDF magic bytes.
+    --limit N            Stop after N successful uploads (useful for smoke).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+# Make ``storage.resume_vault`` importable when run as a script.
+_HERE = Path(__file__).resolve().parent
+_BACKEND = _HERE.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+from storage.resume_vault import parse_resume_filename  # noqa: E402
+
+MAX_PDF_BYTES = 10_000_000
+MAX_FIELD_LEN = 80
+RETRY_DELAYS = (2, 4, 8)
+DEFAULT_EXTENSIONS = (".pdf",)
+
+
+def _truncate(value: str | None, limit: int) -> str | None:
+    if value is None:
+        return None
+    return value[:limit]
+
+
+def _fetch_existing_keys(api_url: str, secret: str | None, timeout: float) -> set[str]:
+    """Return the set of version_keys already in the live vault."""
+    headers = {"Authorization": f"Bearer {secret}"} if secret else {}
+    try:
+        resp = requests.get(f"{api_url}/api/vault/list", headers=headers, timeout=timeout)
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        print(f"  ! Could not fetch existing vault list ({e}); skip-existing disabled")
+        return set()
+    payload = resp.json()
+    return {f.get("version_key") for f in payload.get("files", []) if f.get("version_key")}
+
+
+def _upload_one(
+    api_url: str,
+    secret: str | None,
+    pdf_path: Path,
+    company: str,
+    role: str | None,
+    timeout: float,
+) -> tuple[bool, str]:
+    """POST one PDF. Returns (ok, message). Retries on transient errors."""
+    headers = {"Authorization": f"Bearer {secret}"} if secret else {}
+    last_err = "unknown"
+    for attempt, delay in enumerate((0,) + RETRY_DELAYS):
+        if delay:
+            time.sleep(delay)
+        try:
+            with pdf_path.open("rb") as fh:
+                files = {"pdf": (pdf_path.name, fh, "application/pdf")}
+                data = {"company": company}
+                if role:
+                    data["role"] = role
+                resp = requests.post(
+                    f"{api_url}/api/vault/upload",
+                    headers=headers,
+                    files=files,
+                    data=data,
+                    timeout=timeout,
+                )
+        except requests.RequestException as e:
+            last_err = f"network: {e}"
+            continue
+        if resp.status_code == 200:
+            return True, "ok"
+        # 4xx is permanent (bad PDF, oversize, unauthorized) — don't retry.
+        if 400 <= resp.status_code < 500:
+            try:
+                body = resp.json().get("error", resp.text[:200])
+            except ValueError:
+                body = resp.text[:200]
+            return False, f"HTTP {resp.status_code}: {body}"
+        last_err = f"HTTP {resp.status_code}: {resp.text[:200]}"
+    return False, f"giving up after retries ({last_err})"
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Bulk-upload PDFs to JobScout vault on Render.")
+    p.add_argument(
+        "--source-dir",
+        required=True,
+        help="Local directory to walk (recursively).",
+    )
+    p.add_argument(
+        "--api-url",
+        default=os.environ.get("JOBSCOUT_API_URL", ""),
+        help="Render base URL, e.g. https://your-app.onrender.com (or set JOBSCOUT_API_URL).",
+    )
+    p.add_argument(
+        "--api-secret",
+        default=os.environ.get("JOBSCOUT_API_SECRET", ""),
+        help="Bearer token (or set JOBSCOUT_API_SECRET). Omit if API_SECRET is unset on the server.",
+    )
+    p.add_argument("--dry-run", action="store_true", help="Parse and plan only; send nothing.")
+    p.add_argument(
+        "--no-skip-existing",
+        dest="skip_existing",
+        action="store_false",
+        help="Upload even if version_key already exists in the vault.",
+    )
+    p.set_defaults(skip_existing=True)
+    p.add_argument(
+        "--include-docx",
+        action="store_true",
+        help="Also include .docx (server will reject; useful for an audit listing).",
+    )
+    p.add_argument("--limit", type=int, default=0, help="Stop after N successful uploads.")
+    p.add_argument("--timeout", type=float, default=60.0, help="Per-request timeout (seconds).")
+    args = p.parse_args(argv)
+
+    if not args.api_url:
+        print("ERROR: --api-url is required (or set JOBSCOUT_API_URL).", file=sys.stderr)
+        return 2
+    api_url = args.api_url.rstrip("/")
+
+    src = Path(args.source_dir).expanduser()
+    if not src.is_dir():
+        print(f"ERROR: source dir not found: {src}", file=sys.stderr)
+        return 2
+
+    exts = list(DEFAULT_EXTENSIONS)
+    if args.include_docx:
+        exts.append(".docx")
+
+    candidates = sorted(
+        f for f in src.rglob("*")
+        if f.is_file() and f.suffix.lower() in exts
+    )
+    print(f"Found {len(candidates)} candidate file(s) under {src}")
+    if not candidates:
+        return 0
+
+    existing: set[str] = set()
+    if args.skip_existing and not args.dry_run:
+        existing = _fetch_existing_keys(api_url, args.api_secret or None, args.timeout)
+        print(f"Vault already contains {len(existing)} version_key(s)")
+
+    uploaded = 0
+    skipped_existing = 0
+    skipped_oversize = 0
+    skipped_unparseable = 0
+    failed: list[tuple[str, str]] = []
+
+    for pdf_path in candidates:
+        meta = parse_resume_filename(pdf_path.name)
+        company = _truncate(meta.get("company"), MAX_FIELD_LEN)
+        role = _truncate(meta.get("role"), MAX_FIELD_LEN)
+        vk = meta.get("version_key") or ""
+
+        if not company:
+            print(f"  - {pdf_path.name}: skip (unparseable company)")
+            skipped_unparseable += 1
+            continue
+
+        try:
+            size = pdf_path.stat().st_size
+        except OSError as e:
+            print(f"  - {pdf_path.name}: stat failed ({e})")
+            failed.append((pdf_path.name, f"stat: {e}"))
+            continue
+        if size > MAX_PDF_BYTES:
+            print(f"  - {pdf_path.name}: skip ({size:,} bytes > {MAX_PDF_BYTES:,})")
+            skipped_oversize += 1
+            continue
+
+        if args.skip_existing and vk in existing:
+            skipped_existing += 1
+            continue
+
+        plan = f"{company}" + (f" / {role}" if role else "") + f"  [{vk}]"
+        if args.dry_run:
+            print(f"  · {pdf_path.name} -> {plan}  (dry-run)")
+            uploaded += 1
+            if args.limit and uploaded >= args.limit:
+                break
+            continue
+
+        ok, msg = _upload_one(api_url, args.api_secret or None, pdf_path, company, role, args.timeout)
+        marker = "+" if ok else "x"
+        print(f"  {marker} {pdf_path.name} -> {plan}  {msg}")
+        if ok:
+            uploaded += 1
+            existing.add(vk)
+            if args.limit and uploaded >= args.limit:
+                print(f"Reached --limit {args.limit}; stopping.")
+                break
+        else:
+            failed.append((pdf_path.name, msg))
+
+    print()
+    print("Summary")
+    print(f"  uploaded:           {uploaded}")
+    print(f"  skipped (existing): {skipped_existing}")
+    print(f"  skipped (oversize): {skipped_oversize}")
+    print(f"  skipped (parse):    {skipped_unparseable}")
+    print(f"  failed:             {len(failed)}")
+    for name, msg in failed:
+        print(f"    - {name}: {msg}")
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds a production-ready bulk-upload tool for importing local PDF resumes into the JobScout vault, along with significant improvements to the resume filename parser to support both legacy and AutoApply AI naming conventions.

## Key Changes

### New Files

- **`backend/tools/bulk_upload_to_render.py`** — Standalone CLI tool for bulk-uploading PDFs from a local folder to the live Render vault. Features:
  - Recursive directory walk with configurable file extensions
  - Filename parsing using the same logic as the server
  - Retry logic with exponential backoff for transient network errors
  - Dry-run mode for planning without uploading
  - Skip-existing mode to avoid re-uploading known versions
  - Exclude regex for filtering out unwanted files
  - Detailed summary reporting (uploaded, skipped, failed counts)
  - Preserves original submission dates via filesystem mtime

- **`backend/storage/company_rules.py`** — New canonical source of truth for company and role aliases, extracted from `resume_vault.py` to enable sharing with the AutoApply AI tag builder. Contains:
  - `COMPANY_ALIASES` — 30+ company short-names to canonical display names
  - `ROLE_ALIASES` — 20+ role abbreviations (both legacy and AutoApply canonical forms)
  - `MULTI_WORD_COMPANIES` — Tuple-based multi-word company detection with 3-word and 2-word support
  - `is_job_id()` — Conservative JobID detection for AutoApply grammar (`_{JobID}` segments)

- **`backend/tools/__init__.py`** — Package marker for tools module

### Modified Files

- **`backend/storage/resume_vault.py`**:
  - Refactored to import canonical aliases from `company_rules.py` instead of defining them locally
  - Significantly improved `parse_resume_filename()` with:
    - Longest-prefix-wins name prefix stripping (handles 15+ Naren-family variants)
    - Glued-form detection (e.g., `NarendranathGS` vs `Narendranath_GS`) with uppercase/digit guards
    - 3-word multi-word company detection (e.g., `JPMorgan Chase`)
    - Role-first pattern support for Naren-prefixed files (`Naren_DE_affirm` → role=DE, company=Affirm)
    - Role-only template support (`Naren_DE.pdf` → company=Standard, role=DE)
    - JobID peeling from trailing tokens (AutoApply grammar: `_{JobID}`)
    - Preservation of canonical multi-word names (prevents title-casing `JPMorgan Chase` to `Jpmorgan Chase`)
  - Added `job_id` field to parser output
  - Enhanced `save_pdf_to_vault()` to accept and apply `submitted_at` parameter, stamping filesystem mtime to preserve original application dates

- **`backend/routes/vault_routes.py`**:
  - Added `submitted_at` parameter to `/api/vault/upload` endpoint (both multipart and JSON modes)
  - Validation: ISO 8601 format, year ≥ 2000, not in future (±1 day clock skew tolerance)
  - Passes `submitted_at` through to `save_pdf_to_vault()`

- **`backend/storage/db.py`**:
  - Enhanced `upsert_resume_version()` to accept `submitted_at` parameter
  - When provided, uses `submitted_at` as both `created_at` (on INSERT) and `updated_at` (on INSERT/UPDATE)
  - Enables bulk imports to preserve original application dates instead of stamping with import time

## Notable Implementation Details

- **Name prefix matching** uses longest-prefix-wins with a sorted tuple list to handle overlapping prefixes (e.g., `Narendranath_Edara_` before `Narendranath_`)
- **Glued-form detection** guards against false positives by requiring the remainder to start with uppercase or digit (so `NarendranathG

https://claude.ai/code/session_011jmFxtcRA5PpTtfoYZnjft