### PR TITLE
refactor(frontend): extract API + auth helpers to lib/api.js (1/N)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,9 @@
 import { useState, useMemo, useEffect, useCallback, useRef, memo } from "react";
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, PieChart, Pie, Cell, AreaChart, Area } from "recharts";
+// API + auth helpers extracted to lib/api.js (1/N of the App.jsx split).
+// Same constants, same behavior — only the location changes. Existing
+// `${RENDER_API}/...` template strings work unchanged.
+import { DEFAULT_RENDER_URL, STATIC_URL, RENDER_API, apiToken, authHeaders } from "./lib/api.js";
 
 /* ═══ Theme ═══════════════════════════════════════════════════════════ */
 const TH = {
@@ -324,14 +328,7 @@ function searchRank(job, ql) {
  * The value is read once at module load; the Save action calls location.reload()
  * so every existing `${RENDER_API}/...` template string keeps working.
  */
-const DEFAULT_RENDER_URL = "https://jobscout-api-lasz.onrender.com";
-const _readApiUrl = () => {
-  if (typeof window === "undefined") return "";
-  try { return (window.localStorage.getItem("jobscout_api_url") || "").trim(); }
-  catch { return ""; }
-};
-const RENDER_API = (_readApiUrl() || import.meta.env.VITE_RENDER_URL || "").replace(/\/+$/, "");
-const STATIC_URL = "./api-data.json";
+// DEFAULT_RENDER_URL / RENDER_API / STATIC_URL imported from lib/api.js (above).
 
 /* ───── Vault auth helpers ───────────────────────────────────────────
  * When the backend has API_SECRET set, every /api/vault/* call must
@@ -344,15 +341,7 @@ const STATIC_URL = "./api-data.json";
  *                 token exists, so calls in dev (no API_SECRET) work
  *                 unchanged.
  */
-const apiToken = () => {
-  if (typeof window === "undefined") return "";
-  try { return window.localStorage.getItem("vault_token") || ""; }
-  catch { return ""; }
-};
-const authHeaders = () => {
-  const t = apiToken();
-  return t ? { Authorization: `Bearer ${t}` } : {};
-};
+// apiToken / authHeaders imported from lib/api.js (top of file).
 
 /* ───── First-run setup panel ────────────────────────────────────────────
  * When RENDER_API is "" (fresh browser, no env var, nothing in

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,0 +1,56 @@
+/**
+ * API URL + auth-token helpers — extracted from App.jsx (CLAUDE.md
+ * tech-debt #1, App.jsx split).
+ *
+ * Pure module: no React, no DOM mutation, only localStorage reads.
+ * Everything here can be unit-tested in isolation if we ever add JSDOM-
+ * backed Jest. Until then, the rest of the dashboard imports from here
+ * so the API base URL is configured in exactly one place.
+ *
+ * Behavior preserved exactly: same env-var fallback chain, same trailing-
+ * slash normalization, same localStorage keys ("jobscout_api_url" and
+ * "vault_token"). Existing `${RENDER_API}/...` template strings keep
+ * working unchanged because RENDER_API is exported as a const.
+ */
+export const DEFAULT_RENDER_URL = "https://jobscout-api-lasz.onrender.com";
+export const STATIC_URL = "./api-data.json";
+
+/**
+ * Resolved Render API base URL. Lookup order:
+ *   1. localStorage key "jobscout_api_url" (set via the SetupPanel UI)
+ *   2. import.meta.env.VITE_RENDER_URL (set at Vite build time)
+ *   3. empty string (the SetupPanel renders blocking when this is "")
+ * Trailing slashes are stripped so callers can `${RENDER_API}/api/...`
+ * without worrying about double slashes.
+ */
+const _readApiUrl = () => {
+  if (typeof window === "undefined") return "";
+  try { return (window.localStorage.getItem("jobscout_api_url") || "").trim(); }
+  catch { return ""; }
+};
+
+export const RENDER_API =
+  (_readApiUrl() || import.meta.env.VITE_RENDER_URL || "").replace(/\/+$/, "");
+
+/**
+ * Vault auth helpers.
+ *
+ * When the backend has API_SECRET set, every /api/vault/* call must
+ * carry ``Authorization: Bearer <token>``. We read the token from
+ * localStorage (key "vault_token") so the user can set it once via the
+ * SetupPanel — a proper login UI is tracked as a follow-up.
+ *
+ * apiToken()    — safe read, returns "" outside browser
+ * authHeaders() — spreadable into ``headers: { ... }`` only when a token
+ *                 exists, so calls in dev (no API_SECRET) work unchanged.
+ */
+export const apiToken = () => {
+  if (typeof window === "undefined") return "";
+  try { return window.localStorage.getItem("vault_token") || ""; }
+  catch { return ""; }
+};
+
+export const authHeaders = () => {
+  const t = apiToken();
+  return t ? { Authorization: `Bearer ${t}` } : {};
+};


### PR DESCRIPTION
**PR 1 of ~16 — App.jsx split (CLAUDE.md tech-debt #1).** Starting the App.jsx monolith decomposition (3886 LOC). Lowest-risk first move: pure JS helpers with no React or DOM mutation.

## What moves

`frontend/src/lib/api.js` (new file, 56 LOC):

| Export | Purpose |
|---|---|
| `DEFAULT_RENDER_URL` | SetupPanel default |
| `STATIC_URL` | GitHub Pages JSON fallback path |
| `RENDER_API` | Resolved API base URL |
| `apiToken()` | Read vault Bearer token from localStorage |
| `authHeaders()` | Spread into `headers:` only when token exists |

Same lookup order, same localStorage keys, same trailing-slash normalization. **Existing `${RENDER_API}/api/...` template strings throughout App.jsx work unchanged** because RENDER_API is exported as a `const` resolved at module load.

## App.jsx change

- 1 import line added at the top
- ~14 LOC of helper definitions removed (replaced with comment crumbs)
- 23 lines changed total — minimal surface

## Vite build verification

```
$ node_modules/vite/bin/vite.js build
✓ built in 4.68s
dist/assets/index-D-kGJF-l.js  674.51 kB │ gzip: 189.30 kB
```

Clean build. Bundle size unchanged (helpers are tree-shaken identically whether they live in App.jsx or lib/api.js). The 500KB warning is pre-existing — Recharts is the heavy import.

## Test plan

- [x] `vite build` — clean
- [ ] After deploy: load the dashboard at `/`, verify `RENDER_API` still resolves and data fetches work
- [ ] Open SetupPanel, change API URL, save → reload → confirm new URL is used
- [ ] Set `vault_token` via SetupPanel → `/api/vault/*` calls carry Bearer header

## Roadmap

```
✅ 1/N  lib/api.js              (this PR)
⏳ 2/N  lib/format.js           — fmtSal, timeAgo, salary helpers
⏳ 3/N  lib/theme.js            — TH light/dark tokens
⏳ 4/N  components/BrandLogo.jsx
⏳ 5/N  components/SetupPanel.jsx
⏳ 6/N  components/VaultRow.jsx
⏳ 7/N  components/JobCard.jsx
⏳ 8-16/N  tabs/{Monitor,Pipeline,Trends,Analytics,Companies,Rare,Tracker,Vault,Jobs}Tab.jsx
```

App.jsx LOC reduction will accelerate dramatically once we reach the per-tab extractions (PRs 8+).

https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr)_