### PR TITLE
refactor(frontend): extract Chips + MRow + Chk (9/N)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,6 +34,9 @@ import {
 // Pill + JobCard extracted (PR 8/N).
 import { Pill } from "./components/Pill.jsx";
 import { JobCard } from "./components/JobCard.jsx";
+// Small presentational components (PR 9/N).
+import { Chips } from "./components/Chips.jsx";
+import { MRow, Chk } from "./components/MRow.jsx";
 
 // ATS_META imported from ./lib/jobConstants.js (top of file).
 
@@ -318,55 +321,7 @@ function useApplications() {
 // Pill imported from ./components/Pill.jsx (top).
 
 /* ═══ Chips filter component ═══ */
-function Chips({options,selected,onChange,t,label,pinned}) {
-  const sorted = useMemo(() => {
-    if (!pinned?.length) return options;
-    const ps = new Set(pinned);
-    return [...options.filter(o=>ps.has(o.id)), ...options.filter(o=>!ps.has(o.id))];
-  }, [options, pinned]);
-
-  return (
-    <div style={{display:"flex",flexDirection:"column",gap:7}}>
-      {label && <span style={{fontSize:12,color:t.txM,fontWeight:700,textTransform:"uppercase",letterSpacing:".06em"}}>{label}</span>}
-      <div style={{display:"flex",gap:6,flexWrap:"wrap"}}>
-        {sorted.map(o => {
-          const on = selected.includes(o.id);
-          const isPinned = pinned?.includes(o.id);
-          return (
-            <button key={o.id} onClick={()=>onChange(on?selected.filter(s=>s!==o.id):[...selected,o.id])}
-              style={{padding:"7px 14px",borderRadius:8,border:`1.5px solid ${on?t.ac:isPinned?t.wm+"60":t.bd}`,
-                background:on?t.acL:isPinned?t.wmL+"40":"transparent",
-                color:on?t.ac:t.txS,fontSize:13,fontWeight:on?700:isPinned?600:400,
-                cursor:"pointer",fontFamily:"inherit",transition:"all .15s"}}>
-              {isPinned&&!on?"★ ":""}{o.label}{o.count!=null?` (${o.count})`:""}
-            </button>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-/* ═══ Monitor helpers ═══ */
-function MRow({l,v,c,t}) {
-  return (
-    <div style={{display:"flex",justifyContent:"space-between",alignItems:"center",padding:"10px 0",borderBottom:`1px solid ${t.bd}`}}>
-      <span style={{fontSize:15,color:t.txM,fontWeight:500}}>{l}</span>
-      <span style={{fontSize:15,fontWeight:600,color:c}}>{v}</span>
-    </div>
-  );
-}
-function Chk({done,label,detail,t}) {
-  return (
-    <div style={{display:"flex",alignItems:"flex-start",gap:12}}>
-      <span style={{fontSize:18,marginTop:1}}>{done?"✅":"⬜"}</span>
-      <div>
-        <div style={{fontSize:15,fontWeight:600,color:done?t.ok:t.txM}}>{label}</div>
-        <div style={{fontSize:13,color:t.txM,marginTop:3}}>{detail}</div>
-      </div>
-    </div>
-  );
-}
+// Chips, MRow, Chk imported from ./components/* (PR 9/N).
 
 // JC_STYLES + JobCard extracted to ./lib/jobConstants.js + ./components/JobCard.jsx (PR 8/N).
 

--- a/frontend/src/components/Chips.jsx
+++ b/frontend/src/components/Chips.jsx
@@ -1,0 +1,43 @@
+/**
+ * Chips — multi-select filter UI. Used by the Jobs tab for category +
+ * location filters and a few other places. Pinned items float to the
+ * top of the list (sorted via useMemo so the recompute is amortized).
+ *
+ * Props:
+ *   options  — Array<{id, label, count?}>
+ *   selected — Array<string> of selected ids
+ *   onChange — (newSelected) => void
+ *   t        — theme tokens
+ *   label    — optional uppercase label above the chip row
+ *   pinned   — optional Array<string> of ids that float to the top
+ */
+import { useMemo } from "react";
+
+export function Chips({options,selected,onChange,t,label,pinned}) {
+  const sorted = useMemo(() => {
+    if (!pinned?.length) return options;
+    const ps = new Set(pinned);
+    return [...options.filter(o=>ps.has(o.id)), ...options.filter(o=>!ps.has(o.id))];
+  }, [options, pinned]);
+
+  return (
+    <div style={{display:"flex",flexDirection:"column",gap:7}}>
+      {label && <span style={{fontSize:12,color:t.txM,fontWeight:700,textTransform:"uppercase",letterSpacing:".06em"}}>{label}</span>}
+      <div style={{display:"flex",gap:6,flexWrap:"wrap"}}>
+        {sorted.map(o => {
+          const on = selected.includes(o.id);
+          const isPinned = pinned?.includes(o.id);
+          return (
+            <button key={o.id} onClick={()=>onChange(on?selected.filter(s=>s!==o.id):[...selected,o.id])}
+              style={{padding:"7px 14px",borderRadius:8,border:`1.5px solid ${on?t.ac:isPinned?t.wm+"60":t.bd}`,
+                background:on?t.acL:isPinned?t.wmL+"40":"transparent",
+                color:on?t.ac:t.txS,fontSize:13,fontWeight:on?700:isPinned?600:400,
+                cursor:"pointer",fontFamily:"inherit",transition:"all .15s"}}>
+              {isPinned&&!on?"★ ":""}{o.label}{o.count!=null?` (${o.count})`:""}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/MRow.jsx
+++ b/frontend/src/components/MRow.jsx
@@ -1,0 +1,33 @@
+/**
+ * MRow + Chk — small rows used in the Monitor tab. Pure presentational,
+ * no state.
+ */
+
+/**
+ * One label/value row with a colored value. Used in the Monitor tab's
+ * health summary card.
+ */
+export function MRow({l,v,c,t}) {
+  return (
+    <div style={{display:"flex",justifyContent:"space-between",alignItems:"center",padding:"10px 0",borderBottom:`1px solid ${t.bd}`}}>
+      <span style={{fontSize:15,color:t.txM,fontWeight:500}}>{l}</span>
+      <span style={{fontSize:15,fontWeight:600,color:c}}>{v}</span>
+    </div>
+  );
+}
+
+/**
+ * Checklist row with done/not-done indicator + main label + sub-detail.
+ * Used by the Monitor tab to render setup progress checklist.
+ */
+export function Chk({done,label,detail,t}) {
+  return (
+    <div style={{display:"flex",alignItems:"flex-start",gap:12}}>
+      <span style={{fontSize:18,marginTop:1}}>{done?"✅":"⬜"}</span>
+      <div>
+        <div style={{fontSize:15,fontWeight:600,color:done?t.ok:t.txM}}>{label}</div>
+        <div style={{fontSize:13,color:t.txM,marginTop:3}}>{detail}</div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
PR 9/N — three small presentational components moved out.

- `components/Chips.jsx` (filter-chip row with pin-to-top)
- `components/MRow.jsx` (bundles `MRow` + `Chk` — both Monitor tab helpers)

App.jsx: -52 LOC. Build ✓ 3.49s.

Now starting the **tab extractions** — next PRs move the per-tab JSX blocks one at a time, smallest first.

https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr)_