### PR TITLE
refactor(frontend): extract JobsTab — App.jsx split complete (17/N)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -46,6 +46,7 @@ import { CompaniesTab } from "./tabs/CompaniesTab.jsx";
 import { RareTab } from "./tabs/RareTab.jsx";
 import { TrackerTab } from "./tabs/TrackerTab.jsx";
 import { VaultTab } from "./tabs/VaultTab.jsx";
+import { JobsTab } from "./tabs/JobsTab.jsx";
 
 // ATS_META imported from ./lib/jobConstants.js (top of file).
 
@@ -1684,138 +1685,24 @@ export default function App() {
         </div>
 
         {/* ════════════ JOBS TAB ════════════ */}
-        {tab==="jobs" && <div>
-          {/* Filter bar */}
-          <div className="filter-bar">
-            <input placeholder="Search jobs, skills, companies..." value={q} onChange={e=>sQ(e.target.value)}
-              style={{...iS,flex:"1 1 200px",maxWidth:340}}/>
-            <button onClick={()=>setRemoteOnly(r=>!r)}
-              style={{padding:"10px 14px",borderRadius:8,border:`1.5px solid ${remoteOnly?t.ac:t.bd}`,background:remoteOnly?t.acL:"transparent",color:remoteOnly?t.ac:t.txM,fontSize:14,fontWeight:600,cursor:"pointer",fontFamily:"inherit",whiteSpace:"nowrap"}}>
-              🏠 Remote
-            </button>
-            <button onClick={()=>setH1bOnly(r=>!r)}
-              style={{padding:"10px 14px",borderRadius:8,border:`1.5px solid ${h1bOnly?t.vi:t.bd}`,background:h1bOnly?`${t.vi}12`:"transparent",color:h1bOnly?t.vi:t.txM,fontSize:14,fontWeight:600,cursor:"pointer",fontFamily:"inherit",whiteSpace:"nowrap"}}>
-              🛂 H1B
-            </button>
-            <button onClick={()=>setPlatinumOnly(r=>!r)}
-              style={{padding:"10px 14px",borderRadius:8,border:`1.5px solid ${platinumOnly?"#b8860b":t.bd}`,background:platinumOnly?"#b8860b18":"transparent",color:platinumOnly?"#b8860b":t.txM,fontSize:14,fontWeight:600,cursor:"pointer",fontFamily:"inherit",whiteSpace:"nowrap"}}>
-              ✦ Platinum
-            </button>
-            <button onClick={()=>setHighCompOnly(r=>!r)}
-              style={{padding:"10px 14px",borderRadius:8,border:`1.5px solid ${highCompOnly?t.ok:t.bd}`,background:highCompOnly?`${t.ok}12`:"transparent",color:highCompOnly?t.ok:t.txM,fontSize:14,fontWeight:600,cursor:"pointer",fontFamily:"inherit",whiteSpace:"nowrap"}}>
-              💰 $220K+
-            </button>
-            <select value={selPosted} onChange={e=>setSelPosted(e.target.value)} style={selS}>
-              <option value="All">📅 Any Time</option><option value="24h">Last 24h</option>
-              <option value="3d">Last 3 days</option><option value="7d">Last 7 days</option>
-              <option value="14d">Last 14 days</option><option value="30d">Last 30 days</option>
-            </select>
-            <select value={selSalary} onChange={e=>setSelSalary(e.target.value)} style={selS}>
-              <option value="All">💰 Any Salary</option><option value="$100K+">$100K+</option>
-              <option value="$130K+">$130K+</option><option value="$160K+">$160K+</option>
-              <option value="$200K+">$200K+</option><option value="$250K+">$250K+</option>
-            </select>
-            <select value={so} onChange={e=>sSo(e.target.value)} style={selS}>
-              <option value="relevance">↓ Relevance</option>
-              <option value="salary">↓ Salary</option>
-              <option value="date">↓ Newest</option>
-            </select>
-            <button onClick={()=>setShowFilters(f=>!f)}
-              style={{padding:"10px 14px",borderRadius:8,border:`1.5px solid ${activeN?t.ac:t.bd}`,background:activeN?t.acL:"transparent",color:activeN?t.ac:t.txM,fontSize:14,fontWeight:600,cursor:"pointer",fontFamily:"inherit",whiteSpace:"nowrap"}}>
-              🎛 Filters{activeN?` (${activeN})`:""}
-            </button>
-            {activeN>0 && (
-              <button onClick={clearAll}
-                style={{padding:"10px 12px",borderRadius:8,border:`1.5px solid ${t.er}30`,background:"transparent",color:t.er,fontSize:13,fontWeight:600,cursor:"pointer",fontFamily:"inherit"}}>
-                ✕ Clear
-              </button>
-            )}
-            <span style={{fontSize:14,color:t.txM,fontWeight:600,marginLeft:"auto",whiteSpace:"nowrap"}}>
-              {q.trim() ? `${fj.length} match${fj.length!==1?"es":""}` : `${fj.length} of ${allJobs.length}`}
-            </span>
-          </div>
-
-          {/* Expanded filters */}
-          {showFilters && (
-            <div style={{background:t.cd,borderRadius:14,padding:22,border:`1px solid ${t.bd}`,marginBottom:18,display:"flex",flexDirection:"column",gap:18,boxShadow:t.shS}}>
-              <Chips label="Role Category"   options={opts.roles}  selected={selRoles}  onChange={setSelRoles}  t={t}/>
-              <Chips label="Experience Level" options={opts.exp}    selected={selExp}    onChange={setSelExp}    t={t}/>
-              <Chips label="State"           options={opts.states} selected={selStates} onChange={setSelStates} t={t} pinned={PREFERRED_STATES}/>
-              <Chips label="City / Hub"      options={opts.cities} selected={selCities} onChange={setSelCities} t={t} pinned={PREFERRED_CITIES}/>
-              <Chips label="ATS Platform"    options={opts.ats}    selected={selATS}    onChange={setSelATS}    t={t}/>
-            </div>
-          )}
-
-          {/* R2 #2: empty-state hint when no default resume is configured.
-              Tells users why the "Resume Match" chip is missing and gives
-              them a one-click path to the Vault tab to fix it. Dismissible
-              so it doesn't nag forever once the user knows. */}
-          {!defaultResumeVersion && !defaultHintDismissed && (
-            <div role="note"
-              style={{display:"flex",alignItems:"center",gap:12,padding:"12px 16px",marginBottom:14,
-                background:`${t.ac}10`,border:`1px solid ${t.ac}30`,borderRadius:10,color:t.tx,fontSize:14}}>
-              <span style={{fontSize:18,lineHeight:1}}>💡</span>
-              <span style={{flex:1,lineHeight:1.5}}>
-                Set a default resume in the{" "}
-                <button onClick={() => setTab("vault")}
-                  style={{background:"none",border:"none",padding:0,color:t.ac,fontWeight:700,
-                    fontSize:14,fontFamily:"inherit",cursor:"pointer",textDecoration:"underline"}}>
-                  Vault
-                </button>{" "}
-                tab to see auto-match scores on every job card.
-              </span>
-              <button onClick={dismissDefaultHint}
-                aria-label="Dismiss default-resume hint"
-                title="Dismiss"
-                style={{background:"none",border:`1px solid ${t.bd}`,color:t.txM,
-                  fontSize:14,padding:"3px 10px",borderRadius:6,cursor:"pointer",fontFamily:"inherit"}}>
-                ✕
-              </button>
-            </div>
-          )}
-
-          {/* Job cards */}
-          <div style={{display:"flex",flexDirection:"column",gap:10}}>
-            {fj.slice(0, JOB_FIT_VISIBLE_SLICE).map(j => {
-              const coKey = (j.company || "").toLowerCase();
-              return (
-                <JobCard
-                  key={j.external_id}
-                  j={j}
-                  t={t}
-                  open={xJ === j.external_id}
-                  app={apps[j.external_id]}
-                  coHistory={coHistoryByCompany[coKey] || EMPTY_ARR}
-                  bm={bestMatchByJob[j.external_id]}
-                  jobFit={jobFitByJob[j.external_id]}
-                  vdMap={vdMapByJob[j.external_id] || EMPTY_OBJ}
-                  expandedRows={expandedByJob[j.external_id] || EMPTY_OBJ}
-                  pdfState={pdfStateByJob[j.external_id] || EMPTY_OBJ}
-                  onToggleOpen={toggleCardOpen}
-                  onSave={saveApp}
-                  onRemove={removeApp}
-                  onMarkApplied={markApplied}
-                  onFetchBestMatch={fetchBestMatch}
-                  onToggleVersionRow={toggleVersionRow}
-                  onDownloadResumePdf={downloadResumePdf}
-                />
-              );
-            })}
-            {fj.length > JOB_FIT_VISIBLE_SLICE && (
-              <div style={{textAlign:"center",padding:18,color:t.txM,fontSize:15}}>
-                Showing {JOB_FIT_VISIBLE_SLICE} of {fj.length} — use filters to narrow results
-              </div>
-            )}
-            {fj.length===0 && (
-              <div style={{textAlign:"center",padding:44,color:t.txM,fontSize:16}}>
-                No jobs match.{" "}
-                <button onClick={clearAll} style={{background:"none",border:"none",color:t.ac,cursor:"pointer",fontWeight:700,fontSize:16,fontFamily:"inherit",textDecoration:"underline"}}>
-                  Clear all filters
-                </button>
-              </div>
-            )}
-          </div>
-        </div>}
+        {tab==='jobs' && (
+          <JobsTab state={{
+            t, iS, selS,
+            q, sQ,
+            remoteOnly, setRemoteOnly, h1bOnly, setH1bOnly,
+            platinumOnly, setPlatinumOnly, highCompOnly, setHighCompOnly,
+            selPosted, setSelPosted, selSalary, setSelSalary, so, sSo,
+            showFilters, setShowFilters, activeN, clearAll,
+            opts, selRoles, setSelRoles, selExp, setSelExp,
+            selStates, setSelStates, selCities, setSelCities, selATS, setSelATS,
+            defaultResumeVersion, defaultHintDismissed, dismissDefaultHint, setTab,
+            fj, allJobs, xJ, JOB_FIT_VISIBLE_SLICE,
+            apps, coHistoryByCompany, bestMatchByJob, jobFitByJob,
+            vdMapByJob, expandedByJob, pdfStateByJob,
+            toggleCardOpen, saveApp, removeApp, markApplied,
+            fetchBestMatch, toggleVersionRow, downloadResumePdf,
+          }} />
+        )}
 
         {/* ════════════ RARE SKILLS ════════════ */}
         {tab==="rare" && (

--- a/frontend/src/tabs/JobsTab.jsx
+++ b/frontend/src/tabs/JobsTab.jsx
@@ -1,0 +1,168 @@
+/**
+ * JobsTab — the main jobs view. Filter bar (search + toggles + chips),
+ * default-resume hint banner, then a scrollable list of JobCard.
+ *
+ * State lives in App() — this is presentation only. Each JobCard
+ * receives its own slice of state via props from App, so per-card
+ * memoization survives App re-renders.
+ */
+import { Chips } from "../components/Chips.jsx";
+import { JobCard } from "../components/JobCard.jsx";
+import { EMPTY_ARR, EMPTY_OBJ } from "../lib/jobConstants.js";
+
+const PREFERRED_STATES = ["TX","CA","NY","WA","CO","IL","GA","MA"];
+const PREFERRED_CITIES = ["Remote","Dallas","Austin","Plano","Houston","San Francisco","New York","Seattle"];
+
+export function JobsTab({ state }) {
+  const {
+    t, iS, selS,
+    q, sQ,
+    remoteOnly, setRemoteOnly, h1bOnly, setH1bOnly,
+    platinumOnly, setPlatinumOnly, highCompOnly, setHighCompOnly,
+    selPosted, setSelPosted, selSalary, setSelSalary, so, sSo,
+    showFilters, setShowFilters, activeN, clearAll,
+    opts, selRoles, setSelRoles, selExp, setSelExp,
+    selStates, setSelStates, selCities, setSelCities, selATS, setSelATS,
+    defaultResumeVersion, defaultHintDismissed, dismissDefaultHint, setTab,
+    fj, allJobs, xJ, JOB_FIT_VISIBLE_SLICE,
+    apps, coHistoryByCompany, bestMatchByJob, jobFitByJob,
+    vdMapByJob, expandedByJob, pdfStateByJob,
+    toggleCardOpen, saveApp, removeApp, markApplied,
+    fetchBestMatch, toggleVersionRow, downloadResumePdf,
+  } = state;
+
+  return (
+    <div>
+      {/* Filter bar */}
+      <div className="filter-bar">
+        <input placeholder="Search jobs, skills, companies..." value={q} onChange={e=>sQ(e.target.value)}
+          style={{...iS,flex:"1 1 200px",maxWidth:340}}/>
+        <button onClick={()=>setRemoteOnly(r=>!r)}
+          style={{padding:"10px 14px",borderRadius:8,border:`1.5px solid ${remoteOnly?t.ac:t.bd}`,background:remoteOnly?t.acL:"transparent",color:remoteOnly?t.ac:t.txM,fontSize:14,fontWeight:600,cursor:"pointer",fontFamily:"inherit",whiteSpace:"nowrap"}}>
+          🏠 Remote
+        </button>
+        <button onClick={()=>setH1bOnly(r=>!r)}
+          style={{padding:"10px 14px",borderRadius:8,border:`1.5px solid ${h1bOnly?t.vi:t.bd}`,background:h1bOnly?`${t.vi}12`:"transparent",color:h1bOnly?t.vi:t.txM,fontSize:14,fontWeight:600,cursor:"pointer",fontFamily:"inherit",whiteSpace:"nowrap"}}>
+          🛂 H1B
+        </button>
+        <button onClick={()=>setPlatinumOnly(r=>!r)}
+          style={{padding:"10px 14px",borderRadius:8,border:`1.5px solid ${platinumOnly?"#b8860b":t.bd}`,background:platinumOnly?"#b8860b18":"transparent",color:platinumOnly?"#b8860b":t.txM,fontSize:14,fontWeight:600,cursor:"pointer",fontFamily:"inherit",whiteSpace:"nowrap"}}>
+          ✦ Platinum
+        </button>
+        <button onClick={()=>setHighCompOnly(r=>!r)}
+          style={{padding:"10px 14px",borderRadius:8,border:`1.5px solid ${highCompOnly?t.ok:t.bd}`,background:highCompOnly?`${t.ok}12`:"transparent",color:highCompOnly?t.ok:t.txM,fontSize:14,fontWeight:600,cursor:"pointer",fontFamily:"inherit",whiteSpace:"nowrap"}}>
+          💰 $220K+
+        </button>
+        <select value={selPosted} onChange={e=>setSelPosted(e.target.value)} style={selS}>
+          <option value="All">📅 Any Time</option><option value="24h">Last 24h</option>
+          <option value="3d">Last 3 days</option><option value="7d">Last 7 days</option>
+          <option value="14d">Last 14 days</option><option value="30d">Last 30 days</option>
+        </select>
+        <select value={selSalary} onChange={e=>setSelSalary(e.target.value)} style={selS}>
+          <option value="All">💰 Any Salary</option><option value="$100K+">$100K+</option>
+          <option value="$130K+">$130K+</option><option value="$160K+">$160K+</option>
+          <option value="$200K+">$200K+</option><option value="$250K+">$250K+</option>
+        </select>
+        <select value={so} onChange={e=>sSo(e.target.value)} style={selS}>
+          <option value="relevance">↓ Relevance</option>
+          <option value="salary">↓ Salary</option>
+          <option value="date">↓ Newest</option>
+        </select>
+        <button onClick={()=>setShowFilters(f=>!f)}
+          style={{padding:"10px 14px",borderRadius:8,border:`1.5px solid ${activeN?t.ac:t.bd}`,background:activeN?t.acL:"transparent",color:activeN?t.ac:t.txM,fontSize:14,fontWeight:600,cursor:"pointer",fontFamily:"inherit",whiteSpace:"nowrap"}}>
+          🎛 Filters{activeN?` (${activeN})`:""}
+        </button>
+        {activeN>0 && (
+          <button onClick={clearAll}
+            style={{padding:"10px 12px",borderRadius:8,border:`1.5px solid ${t.er}30`,background:"transparent",color:t.er,fontSize:13,fontWeight:600,cursor:"pointer",fontFamily:"inherit"}}>
+            ✕ Clear
+          </button>
+        )}
+        <span style={{fontSize:14,color:t.txM,fontWeight:600,marginLeft:"auto",whiteSpace:"nowrap"}}>
+          {q.trim() ? `${fj.length} match${fj.length!==1?"es":""}` : `${fj.length} of ${allJobs.length}`}
+        </span>
+      </div>
+
+      {/* Expanded filters */}
+      {showFilters && (
+        <div style={{background:t.cd,borderRadius:14,padding:22,border:`1px solid ${t.bd}`,marginBottom:18,display:"flex",flexDirection:"column",gap:18,boxShadow:t.shS}}>
+          <Chips label="Role Category"   options={opts.roles}  selected={selRoles}  onChange={setSelRoles}  t={t}/>
+          <Chips label="Experience Level" options={opts.exp}    selected={selExp}    onChange={setSelExp}    t={t}/>
+          <Chips label="State"           options={opts.states} selected={selStates} onChange={setSelStates} t={t} pinned={PREFERRED_STATES}/>
+          <Chips label="City / Hub"      options={opts.cities} selected={selCities} onChange={setSelCities} t={t} pinned={PREFERRED_CITIES}/>
+          <Chips label="ATS Platform"    options={opts.ats}    selected={selATS}    onChange={setSelATS}    t={t}/>
+        </div>
+      )}
+
+      {/* R2 #2: empty-state hint when no default resume is configured.
+          Tells users why the "Resume Match" chip is missing and gives
+          them a one-click path to the Vault tab to fix it. Dismissible
+          so it doesn't nag forever once the user knows. */}
+      {!defaultResumeVersion && !defaultHintDismissed && (
+        <div role="note"
+          style={{display:"flex",alignItems:"center",gap:12,padding:"12px 16px",marginBottom:14,
+            background:`${t.ac}10`,border:`1px solid ${t.ac}30`,borderRadius:10,color:t.tx,fontSize:14}}>
+          <span style={{fontSize:18,lineHeight:1}}>💡</span>
+          <span style={{flex:1,lineHeight:1.5}}>
+            Set a default resume in the{" "}
+            <button onClick={() => setTab("vault")}
+              style={{background:"none",border:"none",padding:0,color:t.ac,fontWeight:700,
+                fontSize:14,fontFamily:"inherit",cursor:"pointer",textDecoration:"underline"}}>
+              Vault
+            </button>{" "}
+            tab to see auto-match scores on every job card.
+          </span>
+          <button onClick={dismissDefaultHint}
+            aria-label="Dismiss default-resume hint"
+            title="Dismiss"
+            style={{background:"none",border:`1px solid ${t.bd}`,color:t.txM,
+              fontSize:14,padding:"3px 10px",borderRadius:6,cursor:"pointer",fontFamily:"inherit"}}>
+            ✕
+          </button>
+        </div>
+      )}
+
+      {/* Job cards */}
+      <div style={{display:"flex",flexDirection:"column",gap:10}}>
+        {fj.slice(0, JOB_FIT_VISIBLE_SLICE).map(j => {
+          const coKey = (j.company || "").toLowerCase();
+          return (
+            <JobCard
+              key={j.external_id}
+              j={j}
+              t={t}
+              open={xJ === j.external_id}
+              app={apps[j.external_id]}
+              coHistory={coHistoryByCompany[coKey] || EMPTY_ARR}
+              bm={bestMatchByJob[j.external_id]}
+              jobFit={jobFitByJob[j.external_id]}
+              vdMap={vdMapByJob[j.external_id] || EMPTY_OBJ}
+              expandedRows={expandedByJob[j.external_id] || EMPTY_OBJ}
+              pdfState={pdfStateByJob[j.external_id] || EMPTY_OBJ}
+              onToggleOpen={toggleCardOpen}
+              onSave={saveApp}
+              onRemove={removeApp}
+              onMarkApplied={markApplied}
+              onFetchBestMatch={fetchBestMatch}
+              onToggleVersionRow={toggleVersionRow}
+              onDownloadResumePdf={downloadResumePdf}
+            />
+          );
+        })}
+        {fj.length > JOB_FIT_VISIBLE_SLICE && (
+          <div style={{textAlign:"center",padding:18,color:t.txM,fontSize:15}}>
+            Showing {JOB_FIT_VISIBLE_SLICE} of {fj.length} — use filters to narrow results
+          </div>
+        )}
+        {fj.length===0 && (
+          <div style={{textAlign:"center",padding:44,color:t.txM,fontSize:16}}>
+            No jobs match.{" "}
+            <button onClick={clearAll} style={{background:"none",border:"none",color:t.ac,cursor:"pointer",fontWeight:700,fontSize:16,fontFamily:"inherit",textDecoration:"underline"}}>
+              Clear all filters
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
**Final tab extraction. App.jsx split complete.** 🏁

## What moved

`JobsTab` — the main jobs view with filter bar, search, sort, default-resume hint banner, and JobCard list. ~130 LOC + 40-prop interface.

## App.jsx split complete

Final structure after 17 PRs (#69-79 + #80-84):

```
frontend/src/
├── App.jsx                              1805 LOC ← orchestrator state + tab routing
├── lib/
│   ├── api.js                            ~60 LOC ← RENDER_API, auth, localStorage
│   ├── theme.js                          ~35 LOC ← TH light/dark tokens
│   ├── format.js                         ~30 LOC ← fmtSal, timeAgo
│   └── jobConstants.js                  ~120 LOC ← ATS_META, ROLE_CATS, ST_*, JC_STYLES
├── components/
│   ├── BrandLogo.jsx                     ~20 LOC
│   ├── LogoImg.jsx                       ~80 LOC ← favicon→Clearbit→initial-tile chain
│   ├── ScrapeProgressBar.jsx             ~70 LOC
│   ├── SetupPanel.jsx                   ~135 LOC ← first-run server config
│   ├── Pill.jsx                          ~10 LOC
│   ├── Chips.jsx                         ~45 LOC ← multi-select filter
│   ├── MRow.jsx                          ~35 LOC ← MRow + Chk
│   ├── VaultRow.jsx                     ~130 LOC ← memoized
│   └── JobCard.jsx                      ~310 LOC ← memoized
└── tabs/
    ├── MonitorTab.jsx                   ~310 LOC ← health + admin ops + history
    ├── PipelineTab.jsx                  ~115 LOC ← kanban
    ├── TrendsTab.jsx                     ~50 LOC ← chart + top lists
    ├── AnalyticsTab.jsx                  ~80 LOC ← 4 charts
    ├── CompaniesTab.jsx                  ~40 LOC ← logo grid
    ├── RareTab.jsx                       ~85 LOC ← rare-skills view
    ├── TrackerTab.jsx                   ~310 LOC ← apps + version manager
    ├── VaultTab.jsx                     ~310 LOC ← stats + upload + compare + browse
    └── JobsTab.jsx                      ~170 LOC ← main jobs view
```

## Before / after

- **Before:** App.jsx = 3886 LOC monolith
- **After:** App.jsx = 1805 LOC orchestrator + ~2700 LOC across 22 focused files
- **Each file has a single concern.** Future feature work doesn't have to load a 4000-LOC file to find a button handler.
- **Bundle size unchanged** (~680KB minified / 190KB gzip — tree-shaking sees through the file split)

## Verification

- ✅ Vite build clean at every one of the 17 incremental PRs
- ✅ Final build: 3.76s, no warnings beyond the pre-existing Recharts chunk-size advisory
- ⚠️ Browser smoke test deferred to the user — every tab needs interactive verification before claiming "production-ready"

## CLAUDE.md tech-debt closed

Both tech-debt items targeted today are now fully closed:
- ~~CLAUDE.md tech-debt #1: App.jsx 3886 LOC monolith~~ ✅ (this PR series)
- ~~CLAUDE.md tech-debt #2: server.py 905 LOC monolith~~ ✅ (PRs #60-67)

https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr)_