### PR TITLE
refactor(frontend): drop dead imports + post-split smoke test

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,4 @@
 import { useState, useMemo, useEffect, useCallback, useRef, memo } from "react";
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, PieChart, Pie, Cell, AreaChart, Area } from "recharts";
 // API + auth helpers extracted to lib/api.js (1/N of the App.jsx split).
 // Same constants, same behavior — only the location changes. Existing
 // `${RENDER_API}/...` template strings work unchanged.
@@ -20,10 +19,7 @@ import { VaultRow } from "./components/VaultRow.jsx";
 import {
   ATS_META,
   ROLE_CATS,
-  stopProp,
   EMPTY_OBJ,
-  EMPTY_ARR,
-  jobFitTone as _jobFitTone,
   ST_COLOR,
   ST_LABEL,
   JC_STYLES,


### PR DESCRIPTION
Post-split smoke test of App.jsx. Vite build was already clean; this catches what build can't.

## Findings

**1. Dead imports in App.jsx (fixed in this PR)**

14 names imported but no longer referenced after the tab extractions:

| Module | Names | Why dead |
|---|---|---|
| `recharts` | `BarChart`, `Bar`, `XAxis`, `YAxis`, `Tooltip`, `ResponsiveContainer`, `PieChart`, `Pie`, `Cell`, `AreaChart`, `Area` | All moved to TrendsTab + AnalyticsTab |
| `lib/jobConstants` | `stopProp`, `EMPTY_ARR`, `jobFitTone` (as `_jobFitTone`) | Consumed exclusively by JobCard now |

App.jsx no longer imports `from "recharts"` at all.

**2. Prop-wiring audit (clean)**

For each of the 9 tabs, compared destructured prop names inside the tab against keys passed via `state={{...}}` at the App.jsx call site:

```
✅ AnalyticsTab.jsx:  5 props, all match
✅ CompaniesTab.jsx:  6 props, all match
✅ JobsTab.jsx:      56 props, all match
✅ MonitorTab.jsx:   30 props, all match
✅ PipelineTab.jsx:   5 props, all match
✅ RareTab.jsx:       3 props, all match
✅ TrackerTab.jsx:   34 props, all match
✅ TrendsTab.jsx:     4 props, all match
✅ VaultTab.jsx:     37 props, all match
```

**180 props total** with zero silent undefineds — the most likely failure mode of a per-tab extraction.

**3. Dev server boot (clean)**

Vite dev boots in 1.9s, key modules all return HTTP 200, no transform errors:

```
src/main.jsx             HTTP 200    2KB
src/App.jsx              HTTP 200  278KB (transformed)
src/components/JobCard   HTTP 200   90KB
src/tabs/JobsTab.jsx     HTTP 200   46KB
src/tabs/TrackerTab.jsx  HTTP 200  112KB
src/tabs/VaultTab.jsx    HTTP 200   74KB
src/tabs/MonitorTab.jsx  HTTP 200   96KB
src/lib/jobConstants.js  HTTP 200   36KB
```

**4. Pre-existing finding (NOT this PR's scope)**

`menuOpen` state in App.jsx is write-only — `setMenuOpen(false)` is called when a tab is clicked, but `menuOpen` the value is never read anywhere. Dates to the first commit (`f3cb827`), so it's not from any extraction I did. Leaving for a separate PR since it predates this work.

## What this PR does NOT verify

- **Visual correctness in a real browser** — the container has no Chromium/Firefox/Puppeteer, so I can't drive a tab through real interactions (clicking buttons, opening cards, scrolling). The next interactive session should still spot-check Jobs/Vault/Tracker/Pipeline.

https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWfUtZGNF3vCFifhLTG3Cr)_