### PR TITLE
Slice 3/4 — Onboarding wizard steps 5–6 (resume vault drag-drop + PIN setup)

### DIFF
--- a/frontend/src/components/PdfDropzone.jsx
+++ b/frontend/src/components/PdfDropzone.jsx
@@ -1,0 +1,116 @@
+/**
+ * PdfDropzone — scaffolding for Slice 3 of issue #89.
+ *
+ * Tracking:  https://github.com/narendranathe/job-scout/issues/92
+ * Parent PRD: https://github.com/narendranathe/job-scout/issues/89
+ * Spec:      docs/superpowers/specs/2026-05-17-first-run-onboarding-wizard.md
+ *
+ * Drag-and-drop PDF upload with an editable preview card. Used by
+ * Step 5 of OnboardingWizard, and (optionally) reusable elsewhere
+ * once a "single-upload" UX is needed off the wizard path.
+ *
+ * Flow:
+ *   1. User drops a PDF
+ *   2. POST /api/vault/parse-filename {filename}
+ *      → server echoes parse_resume_filename() result
+ *      → {company, role, version_key, display_name, job_id}
+ *   3. Render preview card with editable Company / Role / Submitted-at
+ *      (Submitted-at defaults to file.lastModified)
+ *   4. User confirms → POST /api/vault/upload (multipart) with bytes +
+ *      edited metadata + submitted_at
+ *   5. Caller (wizard) gets {versionKey, ...} back via onUploaded
+ *
+ * Props:
+ *   onUploaded(result)  — called once on successful upload
+ *   onSkip()            — user dismissed without uploading
+ *
+ * Backend dependency: Slice 3 also adds POST /api/vault/parse-filename
+ * (small echo route in vault_routes.py). Slice 1 adds cookie auth +
+ * CSRF; this component must thread the CSRF header through both POSTs
+ * when a cookie session is active.
+ */
+
+import React, { useState } from 'react';
+
+const API = (import.meta.env.VITE_RENDER_URL || '').replace(/\/+$/, '');
+
+export default function PdfDropzone({ onUploaded, onSkip }) {
+  const [file, setFile] = useState(null);
+  const [meta, setMeta] = useState(null);
+  const [error, setError] = useState('');
+
+  async function handleFile(f) {
+    if (!f) return;
+    if (f.type !== 'application/pdf' && !f.name.toLowerCase().endsWith('.pdf')) {
+      setError('That doesn\'t look like a PDF — only .pdf files are supported.');
+      return;
+    }
+    setFile(f);
+    setError('');
+    // TODO(slice-3): POST /api/vault/parse-filename and set meta from response
+    // Stub: derive a minimal meta from the filename until the endpoint lands
+    setMeta({
+      company: '',
+      role: '',
+      submittedAt: new Date(f.lastModified).toISOString(),
+    });
+  }
+
+  async function handleConfirm() {
+    // TODO(slice-3): multipart POST to /api/vault/upload
+    // const form = new FormData();
+    // form.append('pdf', file);
+    // form.append('company', meta.company);
+    // form.append('role', meta.role);
+    // form.append('submitted_at', meta.submittedAt);
+    // const resp = await fetch(`${API}/api/vault/upload`, { method: 'POST', body: form, headers: authHeaders() });
+    // if (resp.ok) onUploaded(await resp.json());
+    onUploaded({ versionKey: '(scaffold)' });
+  }
+
+  return (
+    <div style={{ border: '2px dashed #888', padding: 24, borderRadius: 8 }}>
+      <h3>Upload your first resume</h3>
+      <input
+        type="file"
+        accept="application/pdf,.pdf"
+        onChange={(e) => handleFile(e.target.files?.[0])}
+      />
+      {error && <p style={{ color: '#c33' }}>{error}</p>}
+      {meta && (
+        <div style={{ marginTop: 16 }}>
+          <label>
+            Company{' '}
+            <input
+              value={meta.company}
+              onChange={(e) => setMeta({ ...meta, company: e.target.value })}
+            />
+          </label>
+          <label>
+            Role{' '}
+            <input
+              value={meta.role}
+              onChange={(e) => setMeta({ ...meta, role: e.target.value })}
+            />
+          </label>
+          <label>
+            Submitted{' '}
+            <input
+              type="datetime-local"
+              value={meta.submittedAt.slice(0, 16)}
+              onChange={(e) =>
+                setMeta({ ...meta, submittedAt: new Date(e.target.value).toISOString() })
+              }
+            />
+          </label>
+          <button onClick={handleConfirm}>Save to vault</button>
+        </div>
+      )}
+      {onSkip && (
+        <button onClick={onSkip} style={{ marginTop: 16 }}>
+          Skip for now
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/PinSetup.jsx
+++ b/frontend/src/components/PinSetup.jsx
@@ -1,0 +1,109 @@
+/**
+ * PinSetup — scaffolding for Slice 3 of issue #89.
+ *
+ * Tracking:  https://github.com/narendranathe/job-scout/issues/92
+ * Parent PRD: https://github.com/narendranathe/job-scout/issues/89
+ *
+ * Step 6 of OnboardingWizard. Two paths:
+ *   A. Create a PIN — 4–8 digit numeric input + confirm field.
+ *      On success calls POST /api/set-pin, then POST /api/login so the
+ *      cookie session is active before the wizard exits.
+ *   B. Skip — explicit consent checkbox required ("Anyone with this
+ *      URL can edit my preferences"). Writes
+ *      user_profile.skip_pin_acknowledged = 1 via POST /api/profile.
+ *
+ * Backend dependency: Slice 1 (#90) adds POST /api/login (cookie auth).
+ * Until that lands, the post-PIN auto-login no-ops and the wizard
+ * falls back to the Bearer header from localStorage.
+ *
+ * Props:
+ *   onComplete()  — PIN saved (either created or skipped); advance to step 7
+ */
+
+import React, { useState } from 'react';
+
+const API = (import.meta.env.VITE_RENDER_URL || '').replace(/\/+$/, '');
+
+export default function PinSetup({ onComplete }) {
+  const [pin, setPin] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [skip, setSkip] = useState(false);
+  const [consent, setConsent] = useState(false);
+  const [error, setError] = useState('');
+
+  function validatePin(p) {
+    if (!/^\d{4,8}$/.test(p)) return 'PIN must be 4–8 digits.';
+    return '';
+  }
+
+  async function handleCreate() {
+    const err = validatePin(pin);
+    if (err) return setError(err);
+    if (pin !== confirm) return setError('PINs do not match.');
+    // TODO(slice-3): POST /api/set-pin {pin}, then POST /api/login {pin}
+    // to obtain the session cookie immediately.
+    onComplete();
+  }
+
+  async function handleSkip() {
+    if (!consent) return setError('Please acknowledge the consent box.');
+    // TODO(slice-3): POST /api/profile {skip_pin_acknowledged: true}
+    onComplete();
+  }
+
+  if (skip) {
+    return (
+      <div>
+        <h3>Skip PIN setup</h3>
+        <p>
+          Without a PIN, anyone who has this dashboard URL can edit your
+          preferences and trigger uploads/scrapes. The site is otherwise
+          open by design — set a PIN later from the Monitor tab.
+        </p>
+        <label>
+          <input
+            type="checkbox"
+            checked={consent}
+            onChange={(e) => setConsent(e.target.checked)}
+          />{' '}
+          I understand and want to skip for now.
+        </label>
+        {error && <p style={{ color: '#c33' }}>{error}</p>}
+        <button onClick={() => setSkip(false)}>Go back and create a PIN</button>
+        <button onClick={handleSkip} disabled={!consent}>
+          Skip
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h3>Lock your dashboard with a PIN</h3>
+      <p>4–8 digits. You'll enter it next time you visit.</p>
+      <label>
+        PIN{' '}
+        <input
+          type="password"
+          inputMode="numeric"
+          maxLength={8}
+          value={pin}
+          onChange={(e) => setPin(e.target.value)}
+        />
+      </label>
+      <label>
+        Confirm{' '}
+        <input
+          type="password"
+          inputMode="numeric"
+          maxLength={8}
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+        />
+      </label>
+      {error && <p style={{ color: '#c33' }}>{error}</p>}
+      <button onClick={handleCreate}>Create PIN</button>
+      <button onClick={() => setSkip(true)}>Skip for now</button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Queued for #92 (Slice 3 of #89 — First-Run Onboarding Wizard PRD).

This branch starts with two scaffolding commits: `frontend/src/components/PdfDropzone.jsx` (drag-drop + editable preview) and `frontend/src/components/PinSetup.jsx` (4–8 digit entry + explicit-consent skip). Subsequent commits will:

1. `POST /api/vault/parse-filename` echo route in `vault_routes.py` (no-auth; ≤256 char filename cap)
2. Wire `PdfDropzone` to the parse-filename echo + the multipart `/api/vault/upload` (with `submitted_at` from file `lastModified`)
3. Set `default_resume_version` on successful upload via `POST /api/profile`
4. Insert Step 5 (`<PdfDropzone>`) and Step 6 (`<PinSetup>`) into `OnboardingWizard.jsx`
5. `MissingPinBanner` — permanent banner when `skip_pin_acknowledged && !pin_hash`
6. `BulkUploadHelpCard` — Path B static panel with copy-pasteable CLI command using the user's actual API URL + token
7. Step 7 success card with summary + "Go to dashboard"

## Dependencies

**Blocks on #90** (Slice 1) for cookie auth so post-PIN-creation cookie persists. **Parallel-safe with #91** (Slice 2) — touches disjoint files; the wizard's reducer (Slice 2) already includes Slice-3 state fields (`uploadedResume`, `pin`, `skipPinAcknowledged`).

## Resolves

- Issue #92
- PRD open question Q4 (defer zip upload — uses CLI script + drag-drop only)

## Test plan

- [ ] Step 5 drag-drop: previews parsed Company/Role with editable fields; "Save" creates the vault entry with correct `submitted_at` from file `lastModified`
- [ ] Step 5 Path B copy block uses the user's actual API URL + token; "Refresh vault" updates the visible count
- [ ] Step 6 PIN validation: 4–8 numeric; mismatch surfaces inline error; on success, cookie is set before step 7
- [ ] Step 6 skip path requires explicit consent checkbox
- [ ] `MissingPinBanner` shows on every page when `skip_pin_acknowledged && !pin_hash`
- [ ] Final commit includes all wizard state (roles + companies + locations + comp + default_resume_version + onboarded_at)
- [ ] `POST /api/vault/parse-filename` returns documented shape; rejects empty + oversize inputs

https://claude.ai/code/session_011jmFxtcRA5PpTtfoYZnjft

---
_Generated by [Claude Code](https://claude.ai/code/session_011jmFxtcRA5PpTtfoYZnjft)_