### PR TITLE
Slice 4/4 — Login screen, read-only preview enforcement, reset-onboarding admin

### DIFF
--- a/frontend/src/components/LoginScreen.jsx
+++ b/frontend/src/components/LoginScreen.jsx
@@ -1,0 +1,102 @@
+/**
+ * LoginScreen — scaffolding for Slice 4 of issue #89.
+ *
+ * Tracking:  https://github.com/narendranathe/job-scout/issues/93
+ * Parent PRD: https://github.com/narendranathe/job-scout/issues/89
+ * Spec:      docs/superpowers/specs/2026-05-17-first-run-onboarding-wizard.md
+ *
+ * Shown when user_profile.pin_hash != "" AND no valid jobscout_session
+ * cookie. App.jsx mounts this in place of the dashboard or wizard
+ * until the user signs in.
+ *
+ * Backend dependency: Slice 1 (#90) ships POST /api/login (PIN →
+ * signed cookie). Until then this scaffold no-ops on submit.
+ *
+ * UX requirements (see issue #93 acceptance criteria):
+ *   - Full-page card layout, no chrome
+ *   - PIN input is type=password inputMode=numeric maxLength=8
+ *   - Wrong-PIN inline error; 3 attempts → 10s cooldown (client-side)
+ *   - "Forgot PIN?" expandable hint (no recovery flow; admin reset only)
+ *   - On 200: redirect to whatever path was originally requested
+ *     (default /); pass `redirectTo` via props
+ *
+ * Props:
+ *   redirectTo  — path to navigate to after successful login (default "/")
+ *   onLogin()   — optional callback (e.g., to refresh top-level state)
+ */
+
+import React, { useState } from 'react';
+
+const API = (import.meta.env.VITE_RENDER_URL || '').replace(/\/+$/, '');
+const COOLDOWN_AFTER = 3;
+const COOLDOWN_MS = 10_000;
+
+export default function LoginScreen({ redirectTo = '/', onLogin }) {
+  const [pin, setPin] = useState('');
+  const [error, setError] = useState('');
+  const [attempts, setAttempts] = useState(0);
+  const [cooldownUntil, setCooldownUntil] = useState(0);
+  const [forgot, setForgot] = useState(false);
+
+  const inCooldown = Date.now() < cooldownUntil;
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (inCooldown) return;
+    if (!/^\d{4,8}$/.test(pin)) {
+      setError('PIN must be 4–8 digits.');
+      return;
+    }
+
+    // TODO(slice-4): POST /api/login {pin}
+    // const resp = await fetch(`${API}/api/login`, { … });
+    // if (resp.ok) { onLogin?.(); window.location.href = redirectTo; return; }
+    // setError('Invalid PIN');
+    // setAttempts(a => a + 1);
+    // if (attempts + 1 >= COOLDOWN_AFTER) setCooldownUntil(Date.now() + COOLDOWN_MS);
+    setError('Login endpoint not implemented yet (scaffold).');
+  }
+
+  return (
+    <div style={{ maxWidth: 360, margin: '120px auto', padding: 24, textAlign: 'center' }}>
+      <h1>JobScout</h1>
+      <p style={{ opacity: 0.7 }}>Enter your PIN to continue.</p>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="password"
+          inputMode="numeric"
+          maxLength={8}
+          autoFocus
+          autoComplete="one-time-code"
+          value={pin}
+          onChange={(e) => setPin(e.target.value)}
+          disabled={inCooldown}
+          style={{ fontSize: 24, letterSpacing: '0.4em', padding: 12, width: '100%' }}
+        />
+        {error && <p style={{ color: '#c33', marginTop: 8 }}>{error}</p>}
+        {inCooldown && (
+          <p style={{ color: '#c33', marginTop: 8 }}>
+            Too many attempts. Try again in {Math.ceil((cooldownUntil - Date.now()) / 1000)}s.
+          </p>
+        )}
+        <button type="submit" disabled={inCooldown} style={{ marginTop: 16, width: '100%' }}>
+          Sign in
+        </button>
+      </form>
+      <button
+        onClick={() => setForgot((f) => !f)}
+        style={{ marginTop: 24, background: 'none', border: 'none', textDecoration: 'underline' }}
+      >
+        Forgot PIN?
+      </button>
+      {forgot && (
+        <p style={{ fontSize: 12, opacity: 0.7, marginTop: 8 }}>
+          The PIN is stored as a pbkdf2 hash and can't be recovered. To
+          reset, call <code>POST /api/admin/reset-pin</code> with your
+          API_SECRET Bearer token, or use the Monitor tab on a session
+          that already has admin access.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/PreviewModeBanner.jsx
+++ b/frontend/src/components/PreviewModeBanner.jsx
@@ -1,0 +1,67 @@
+/**
+ * PreviewModeBanner — scaffolding for Slice 4 of issue #89.
+ *
+ * Tracking:  https://github.com/narendranathe/job-scout/issues/93
+ * Parent PRD: https://github.com/narendranathe/job-scout/issues/89
+ *
+ * Persistent top-of-page banner shown when the user chose
+ * "Skip — I'm just looking" on wizard step 1
+ * (user_profile.onboarded_at == "preview").
+ *
+ * Behavior:
+ *   - Visible on every dashboard page in preview mode
+ *   - Single CTA "Start setup" → /setup?force=1
+ *   - Dismiss link writes user_profile.preview_banner_dismissed = 1
+ *     for the current session (Slice 4 may store this in
+ *     localStorage instead — TBD during implementation)
+ *
+ * Companion piece: a click-interceptor in App.jsx that intercepts any
+ * write surface (Tracker pills, Vault upload, Save buttons, scrape
+ * trigger) and opens a modal pointing back at the wizard. This banner
+ * is the always-visible nudge; the modal is the write-time block.
+ *
+ * Props:
+ *   onDismiss()  — user clicked the dismiss link
+ */
+
+import React from 'react';
+
+export default function PreviewModeBanner({ onDismiss }) {
+  return (
+    <div
+      role="status"
+      style={{
+        background: '#fff8e1',
+        borderBottom: '1px solid #f0c040',
+        padding: '8px 16px',
+        fontSize: 13,
+        textAlign: 'center',
+      }}
+    >
+      <strong>Preview mode.</strong>{' '}
+      You're browsing JobScout without setting up. Any changes you try
+      to make will prompt you to finish setup first.
+      <a
+        href="/setup?force=1"
+        style={{ marginLeft: 12, textDecoration: 'underline' }}
+      >
+        Start setup
+      </a>
+      {onDismiss && (
+        <button
+          onClick={onDismiss}
+          aria-label="Dismiss banner"
+          style={{
+            marginLeft: 12,
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            opacity: 0.6,
+          }}
+        >
+          ✕
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Queued for #93 (Slice 4 of #89 — First-Run Onboarding Wizard PRD).

This branch starts with two scaffolding commits: `frontend/src/components/LoginScreen.jsx` (full-page PIN entry with 3-attempt cooldown + forgot-PIN hint) and `frontend/src/components/PreviewModeBanner.jsx` (persistent top-of-page banner for skip-the-wizard visitors). Subsequent commits will:

1. Mount `<LoginScreen>` in `App.jsx` when `pin_hash != ""` and no valid session cookie
2. Add `mode = "preview" | "full"` context in `frontend/src/lib/auth.js`
3. Write-attempt interceptor: in preview mode, intercept every write surface (Tracker pills, Vault upload, Save buttons, scrape trigger) → modal "Set up first"
4. "Reset onboarding" admin card in `MonitorTab` (clears `onboarded_at` + `skip_pin_acknowledged`)
5. `POST /api/admin/reset-onboarding` endpoint (Bearer-gated like other admin ops)
6. Three new doctor counters: `onboarded_users`, `wizard_steps_skipped`, `tracked_but_unscraped_companies_count`
7. `alerts/notifier.notify_unscraped_tracking()` — rate-limited Discord ping (≤1/day) when user adds typed-but-unscraped names to `tracked_companies`

## Dependencies

**Blocks on #90, #91, #92** — all three prior slices must merge first. This is the final polish + production guardrails.

## Resolves

- Issue #93
- PRD open questions Q1 (Discord ping with rate limit) and Q2 (read-only preview enforcement)

## Test plan

- [ ] Returning user with PIN: page load → `<LoginScreen>` → enter PIN → land on requested route
- [ ] Wrong PIN: inline error; 3 wrong attempts triggers 10s cooldown
- [ ] Preview-mode visitor: every write surface opens "Set up first" modal, not the action
- [ ] Preview banner shows on every page until `onboarded_at != "preview"`
- [ ] "Reset onboarding": confirm → POST → next page load shows wizard with prior roles/companies/vault preserved
- [ ] Doctor endpoint includes 3 new counters
- [ ] Adding a never-scraped company to `tracked_companies` fires exactly one Discord ping per day (batched), max
- [ ] No-PIN-skip flow still works: `MissingPinBanner` (from Slice 3) coexists with everything above

https://claude.ai/code/session_011jmFxtcRA5PpTtfoYZnjft

---
_Generated by [Claude Code](https://claude.ai/code/session_011jmFxtcRA5PpTtfoYZnjft)_