### PR TITLE
Slice 3/4 — onboarding wizard steps 5-6 (resume drag-drop + PIN) + parse-filename

### DIFF
--- a/backend/routes/vault_routes.py
+++ b/backend/routes/vault_routes.py
@@ -134,8 +134,17 @@ def _vault_require_auth():
     them without the Authorization header during CORS preflight, so a 401
     here would break the dashboard before the real request ever leaves
     the browser.
+
+    /api/vault/parse-filename is also allowed through — it's a read-only
+    pure-function echo (no DB hits, no PII, microsecond cost) so the
+    wizard can preview the parser's output before the user has a session.
+    Adding it to the auth gate would force a chicken-and-egg flow: log
+    in → upload a resume → log in stays valid; but the wizard hasn't
+    logged in yet at the point it shows the dropzone preview.
     """
     if request.method == "OPTIONS":
+        return None
+    if request.path == "/api/vault/parse-filename":
         return None
     # Local import so a circular dependency between routes._auth and
     # routes.vault_routes can't accidentally creep in via top-level imports.
@@ -582,6 +591,35 @@ def vault_version_pdf(version_key):
         as_attachment=True,
         download_name=pdf_filename,
     )
+
+
+@vault_bp.route("/api/vault/parse-filename", methods=["POST", "OPTIONS"])
+def vault_parse_filename():
+    """Echo of ``parse_resume_filename`` for the wizard's drag-drop preview.
+
+    PRD #89 Slice 3. The wizard reads a dropped PDF's name as text and
+    sends it here to get back ``{company, role, version_key, …}``
+    without having to re-implement the parser in JavaScript. Pure
+    function, no DB write, no PII, ~microseconds.
+
+    Auth: explicitly allowed through in ``_vault_require_auth`` so the
+    wizard can preview parser output BEFORE the user has logged in.
+    """
+    if request.method == "OPTIONS":
+        return "", 200
+
+    data = request.get_json(silent=True) or {}
+    fn = (data.get("filename") or "").strip()
+    if not fn:
+        return jsonify({"error": "filename required"}), 400
+    # Reasonable cap — modern filesystems allow 255 bytes, but a 256
+    # tolerance covers UTF-8 + accidental whitespace without spending
+    # CPU on absurd inputs.
+    if len(fn) > 256:
+        return jsonify({"error": "filename too long (max 256 chars)"}), 400
+
+    from storage.resume_vault import parse_resume_filename
+    return jsonify(parse_resume_filename(fn)), 200
 
 
 @vault_bp.after_request

--- a/backend/tests/test_vault_parse_filename.py
+++ b/backend/tests/test_vault_parse_filename.py
@@ -1,0 +1,131 @@
+"""Tests for /api/vault/parse-filename — the wizard's drag-drop preview.
+
+PRD #89 Slice 3. Three things must hold:
+
+1. No auth required (the wizard runs this before login).
+2. Returns the same shape as ``parse_resume_filename()``.
+3. Empty + oversize inputs return 400 (cheap validation).
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+SECRET = "test-secret-xyz"
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "test.db")
+    vault_dir = str(tmp_path / "vault")
+    os.makedirs(vault_dir, exist_ok=True)
+
+    from storage.db import init_db
+    from storage.profile_manager import init_profile_tables
+    init_db(db_path)
+    init_profile_tables(db_path)
+
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.setenv("API_SECRET", SECRET)
+    monkeypatch.setenv("VAULT_DIR", vault_dir)
+
+    for mod in list(sys.modules):
+        if mod == "server" or mod.startswith("routes.") or mod == "core.config":
+            del sys.modules[mod]
+
+    import server
+    from core import config as _config
+    _config.DB_PATH = db_path
+    server.DB_PATH = db_path
+    server.app.config["TESTING"] = True
+
+    with server.app.test_client() as c:
+        yield c
+
+
+def test_parse_filename_no_auth_required(client):
+    """No Authorization header → still 200. Key acceptance criterion."""
+    resp = client.post(
+        "/api/vault/parse-filename",
+        json={"filename": "Narendranath_GS_DE.pdf"},
+    )
+    assert resp.status_code == 200, (
+        f"unauthenticated request rejected: {resp.status_code} "
+        f"{resp.get_data(as_text=True)[:200]}"
+    )
+
+
+def test_parse_filename_returns_company_and_role(client):
+    resp = client.post(
+        "/api/vault/parse-filename",
+        json={"filename": "Narendranath_GS_DE.pdf"},
+    )
+    data = resp.get_json()
+    assert data["company"] == "Goldman Sachs"
+    assert data["role"] == "Data Engineer"
+
+
+def test_parse_filename_returns_expected_keys(client):
+    resp = client.post(
+        "/api/vault/parse-filename",
+        json={"filename": "Narendranath_Meta_MLE.pdf"},
+    )
+    data = resp.get_json()
+    for k in ("original_filename", "company", "role", "version_key",
+              "display_name", "extension"):
+        assert k in data, f"missing key {k}: {data}"
+
+
+def test_parse_filename_rejects_empty(client):
+    resp = client.post("/api/vault/parse-filename", json={"filename": ""})
+    assert resp.status_code == 400
+    assert "required" in resp.get_json()["error"].lower()
+
+
+def test_parse_filename_rejects_missing_field(client):
+    resp = client.post("/api/vault/parse-filename", json={})
+    assert resp.status_code == 400
+
+
+def test_parse_filename_rejects_whitespace_only(client):
+    resp = client.post(
+        "/api/vault/parse-filename",
+        json={"filename": "    "},
+    )
+    assert resp.status_code == 400
+
+
+def test_parse_filename_rejects_oversize_input(client):
+    huge = "A" * 300 + ".pdf"
+    resp = client.post(
+        "/api/vault/parse-filename",
+        json={"filename": huge},
+    )
+    assert resp.status_code == 400
+    assert "too long" in resp.get_json()["error"].lower()
+
+
+def test_parse_filename_handles_257_chars_rejected(client):
+    """Boundary: 257 chars rejected, 256 accepted."""
+    just_over = "A" * 253 + ".pdf"  # 257 chars total
+    assert len(just_over) == 257
+    resp = client.post("/api/vault/parse-filename", json={"filename": just_over})
+    assert resp.status_code == 400
+
+
+def test_parse_filename_with_bearer_token_also_works(client):
+    """Bearer auth shouldn't be rejected either — the gate is just open."""
+    resp = client.post(
+        "/api/vault/parse-filename",
+        json={"filename": "Narendranath_Meta_MLE.pdf"},
+        headers={"Authorization": f"Bearer {SECRET}"},
+    )
+    assert resp.status_code == 200
+
+
+def test_parse_filename_options_passes(client):
+    """OPTIONS preflight returns 200."""
+    resp = client.open("/api/vault/parse-filename", method="OPTIONS")
+    assert resp.status_code in (200, 204)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,6 +19,9 @@ import { SetupPanel } from "./components/SetupPanel.jsx";
 // read-only preview mode, which Slice 4 will enforce).
 import { OnboardingWizard } from "./tabs/OnboardingWizard.jsx";
 import { detectOnboardingState } from "./lib/wizard.js";
+// Permanent banner shown when the user skipped PIN setup during the
+// wizard (Slice 3). Self-decides whether to render based on profile.
+import { MissingPinBanner } from "./components/MissingPinBanner.jsx";
 // Vault tab row (memoized, PR 6/N).
 import { VaultRow } from "./components/VaultRow.jsx";
 // Shared job constants + helpers (PR 7/N + PR 8/N).
@@ -402,6 +405,10 @@ export default function App() {
   const [defaultResumeVersion, setDefaultResumeVersion] = useState(null);
   const [defaultUpdating, setDefaultUpdating] = useState(false);
   const [defaultMsg, setDefaultMsg] = useState(null);
+  // Full /api/profile response — keep around so MissingPinBanner can
+  // self-decide whether to render (has_pin + skip_pin_acknowledged).
+  // Slice 4 will use this for read-only preview enforcement too.
+  const [profile, setProfile] = useState(null);
   // R2 #2: empty-state hint banner above the Jobs list when no default
   // resume is configured. Persisted dismissal in localStorage so users
   // who've already seen the hint don't get pestered every reload.
@@ -437,6 +444,7 @@ export default function App() {
         const d = await r.json();
         if (cancelled) return;
         setDefaultResumeVersion(d.default_resume_version || null);
+        setProfile(d);
       } catch (_e) { /* offline / 5xx — silently no chip */ }
     })();
     return () => { cancelled = true; };
@@ -1655,6 +1663,8 @@ export default function App() {
   return (
     <div style={{minHeight:"100vh",background:t.bg,fontFamily:"'Source Sans 3',sans-serif",color:t.tx,fontSize:16}}>
 
+      <MissingPinBanner t={t} profile={profile} />
+
       {/* ═══ NAV ═══ */}
       <nav style={{position:"sticky",top:0,zIndex:50,background:t.nav,backdropFilter:"blur(20px)",borderBottom:`1px solid ${t.bd}`}}>
         <div className="nav-wrap" style={{padding:"12px 24px"}}>
@@ -1709,8 +1719,20 @@ export default function App() {
               window.history.replaceState({}, "", u.toString());
             }
             // Refetch profile so the rest of the dashboard sees the new
-            // tracked_companies / dream_role_keywords / etc.
+            // tracked_companies / dream_role_keywords / etc. — and so
+            // MissingPinBanner appears if PIN was skipped.
             refetch?.();
+            if (RENDER_API) {
+              fetch(`${RENDER_API}/api/profile`)
+                .then((r) => (r.ok ? r.json() : null))
+                .then((d) => {
+                  if (d) {
+                    setProfile(d);
+                    setDefaultResumeVersion(d.default_resume_version || null);
+                  }
+                })
+                .catch(() => {});
+            }
           }}
           onSkip={() => {
             // Preview mode — Slice 4 will gate writes behind a modal.

--- a/frontend/src/components/BulkUploadHelpCard.jsx
+++ b/frontend/src/components/BulkUploadHelpCard.jsx
@@ -1,0 +1,115 @@
+/**
+ * BulkUploadHelpCard — "I have many resumes" panel (Path B of Step 5).
+ *
+ * PRD #89 Slice 3. Static informational card that shows the user how to
+ * point ``backend/tools/bulk_upload_to_render.py`` at THIS dashboard's
+ * Render URL + their API token. We inline the values dynamically so
+ * the user doesn't have to translate placeholders.
+ *
+ * Includes a "Refresh vault" button so the user can confirm uploads
+ * land while the script runs.
+ */
+import { useState } from "react";
+
+export function BulkUploadHelpCard({ t, apiBase, apiToken, onRefresh }) {
+  const [count, setCount] = useState(null);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = async () => {
+    setBusy(true);
+    try {
+      const r = await fetch(`${apiBase}/api/vault/stats`, {
+        headers: apiToken ? { Authorization: `Bearer ${apiToken}` } : {},
+        credentials: "include",
+      });
+      if (r.ok) {
+        const d = await r.json();
+        const n = d.stats?.pdf_count || d.pdf_count || 0;
+        setCount(n);
+        onRefresh?.(n);
+      }
+    } catch (_) {
+      // Silently no-op — count stays as it was.
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const tokenPlaceholder = apiToken
+    ? '"$YOUR_TOKEN"' // The user already has one; we don't echo it.
+    : '"<set if API_SECRET configured, else leave blank>"';
+
+  const script = [
+    "cd backend",
+    `$env:JOBSCOUT_API_URL    = "${apiBase || "<dashboard URL>"}"`,
+    `$env:JOBSCOUT_API_SECRET = ${tokenPlaceholder}`,
+    `python -m tools.bulk_upload_to_render --source-dir "<your folder>" \\`,
+    `    --exclude '(?i)^(?:jayanth|lankipalli|naru_kiran|sai_maruthi|siva\\s+chandan)'`,
+  ].join("\n");
+
+  return (
+    <div
+      style={{
+        padding: 18,
+        borderRadius: 10,
+        border: `1px solid ${t.bd}`,
+        background: t.bgS,
+      }}
+    >
+      <div style={{ fontWeight: 700, fontSize: 14, color: t.tx, marginBottom: 8 }}>
+        Have many resumes?
+      </div>
+      <p style={{ color: t.txM, fontSize: 13, margin: "0 0 10px" }}>
+        Bulk-upload a whole folder via the CLI:
+      </p>
+      <pre
+        style={{
+          background: t.cd,
+          border: `1px solid ${t.bd}`,
+          borderRadius: 8,
+          padding: 12,
+          color: t.tx,
+          fontSize: 12,
+          fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+          overflowX: "auto",
+          margin: 0,
+        }}
+      >
+        {script}
+      </pre>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          marginTop: 12,
+          flexWrap: "wrap",
+        }}
+      >
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={busy}
+          style={{
+            padding: "6px 12px",
+            borderRadius: 6,
+            border: `1px solid ${t.bd}`,
+            background: t.cd,
+            color: t.tx,
+            fontSize: 12,
+            fontWeight: 600,
+            cursor: busy ? "wait" : "pointer",
+            fontFamily: "inherit",
+          }}
+        >
+          {busy ? "Checking…" : "🔄 Refresh vault"}
+        </button>
+        {count !== null && (
+          <span style={{ color: t.txM, fontSize: 12 }}>
+            {count} {count === 1 ? "PDF" : "PDFs"} in vault
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/MissingPinBanner.jsx
+++ b/frontend/src/components/MissingPinBanner.jsx
@@ -1,0 +1,69 @@
+/**
+ * MissingPinBanner — persistent yellow banner shown when no PIN is set
+ * and the user acknowledged the skip during onboarding.
+ *
+ * PRD #89 Slice 3. Renders at the top of the dashboard until a PIN is
+ * configured. Click → re-enters the wizard at step 6 via /setup?force=1.
+ *
+ * Props:
+ *   t:        theme tokens
+ *   profile:  the /api/profile response (or null while loading)
+ *
+ * The decision to render is encapsulated here: only show when
+ * skip_pin_acknowledged == true AND has_pin == false. The dashboard
+ * mounts this unconditionally; the component self-decides whether to
+ * appear.
+ */
+export function MissingPinBanner({ t, profile }) {
+  if (!profile) return null;
+  if (profile.has_pin) return null;
+  if (!profile.skip_pin_acknowledged) return null;
+
+  const goSetPin = () => {
+    if (typeof window === "undefined") return;
+    const u = new URL(window.location.href);
+    u.pathname = "/setup";
+    u.searchParams.set("force", "1");
+    u.searchParams.set("step", "6"); // hint; OnboardingWizard will honour later
+    window.location.href = u.toString();
+  };
+
+  return (
+    <div
+      role="alert"
+      style={{
+        background: t.wm || "#c47a00",
+        color: "#fff",
+        padding: "10px 16px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 12,
+        fontSize: 13,
+        fontWeight: 500,
+        flexWrap: "wrap",
+      }}
+    >
+      <span>
+        ⚠️ No PIN set — anyone with this URL can edit your preferences.
+      </span>
+      <button
+        type="button"
+        onClick={goSetPin}
+        style={{
+          background: "rgba(255,255,255,0.18)",
+          color: "#fff",
+          border: "1px solid rgba(255,255,255,0.35)",
+          padding: "6px 12px",
+          borderRadius: 6,
+          fontSize: 12,
+          fontWeight: 600,
+          cursor: "pointer",
+          fontFamily: "inherit",
+        }}
+      >
+        Set a PIN
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/PdfDropzone.jsx
+++ b/frontend/src/components/PdfDropzone.jsx
@@ -1,0 +1,406 @@
+/**
+ * PdfDropzone — drag-and-drop PDF upload with editable parsed metadata.
+ *
+ * PRD #89 Slice 3, Step 5 (Path A: "I have one resume to start").
+ *
+ * Flow:
+ *   1. User drops/picks a PDF
+ *   2. We read it as ArrayBuffer + base64 (vault upload accepts both
+ *      base64 JSON and multipart; we use base64 because it survives
+ *      the existing CSRF/JSON path with no extra encoder gymnastics)
+ *   3. POST /api/vault/parse-filename → preview {company, role, …}
+ *   4. User edits the auto-parsed fields if they want
+ *   5. POST /api/vault/upload with the bytes + edited metadata
+ *   6. onUploaded(versionKey) fires so the wizard can set it as default
+ *
+ * Props:
+ *   t:           theme tokens
+ *   apiBase:     RENDER_API
+ *   authHeaders: () => {Authorization?: string} (from lib/api.js)
+ *   csrfToken:   string from localStorage
+ *   onUploaded(result): called on success with the upload API response
+ *                       (result.version_key is what the wizard tracks)
+ */
+import { useRef, useState } from "react";
+
+const MAX_PDF_BYTES = 10_000_000; // matches backend limit
+
+export function PdfDropzone({ t, apiBase, authHeaders, csrfToken, onUploaded }) {
+  const inputRef = useRef(null);
+  const [drag, setDrag] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+  const [stage, setStage] = useState("idle"); // idle | preview | uploading | done
+  const [file, setFile] = useState(null);
+  const [pdfBase64, setPdfBase64] = useState("");
+  const [preview, setPreview] = useState(null); // {company, role, …}
+  const [editCompany, setEditCompany] = useState("");
+  const [editRole, setEditRole] = useState("");
+  const [submittedAt, setSubmittedAt] = useState("");
+
+  const reset = () => {
+    setStage("idle");
+    setFile(null);
+    setPdfBase64("");
+    setPreview(null);
+    setEditCompany("");
+    setEditRole("");
+    setError(null);
+  };
+
+  const onFile = async (f) => {
+    setError(null);
+    if (!f) return;
+    if (!/\.pdf$/i.test(f.name)) {
+      setError("File must be a PDF (.pdf)");
+      return;
+    }
+    if (f.size > MAX_PDF_BYTES) {
+      setError(`PDF too large: ${(f.size / 1e6).toFixed(1)} MB (max 10 MB)`);
+      return;
+    }
+
+    setBusy(true);
+    try {
+      // ArrayBuffer → base64 (no Buffer in browser; use FileReader's
+      // readAsDataURL and strip the prefix).
+      const dataUrl = await new Promise((resolve, reject) => {
+        const r = new FileReader();
+        r.onerror = () => reject(r.error || new Error("read failed"));
+        r.onload = () => resolve(r.result);
+        r.readAsDataURL(f);
+      });
+      const b64 = String(dataUrl).split(",")[1] || "";
+
+      // Ask backend to parse the filename
+      const parseResp = await fetch(`${apiBase}/api/vault/parse-filename`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ filename: f.name }),
+      });
+      let parsed = {};
+      if (parseResp.ok) parsed = await parseResp.json();
+
+      setFile(f);
+      setPdfBase64(b64);
+      setPreview(parsed);
+      setEditCompany(parsed.company || "");
+      setEditRole(parsed.role || "");
+      // File.lastModified is the mtime when the user picked the file,
+      // which matches the PRD's "default to file's lastModified" rule.
+      const mod = new Date(f.lastModified || Date.now());
+      setSubmittedAt(mod.toISOString().slice(0, 10));
+      setStage("preview");
+    } catch (e) {
+      setError(`Could not read file: ${e?.message || e}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onDrop = (e) => {
+    e.preventDefault();
+    setDrag(false);
+    onFile(e.dataTransfer.files?.[0]);
+  };
+
+  const onPick = (e) => {
+    onFile(e.target.files?.[0]);
+  };
+
+  const save = async () => {
+    if (!file || !pdfBase64) return;
+    if (!editCompany.trim()) {
+      setError("Company is required");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    setStage("uploading");
+    try {
+      const body = {
+        pdf_base64: pdfBase64,
+        company: editCompany.trim(),
+        role: editRole.trim() || null,
+        filename: file.name,
+        submitted_at: submittedAt
+          ? new Date(submittedAt).toISOString()
+          : null,
+      };
+      const resp = await fetch(`${apiBase}/api/vault/upload`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(csrfToken ? { "X-CSRF-Token": csrfToken } : {}),
+          ...(authHeaders ? authHeaders() : {}),
+        },
+        credentials: "include",
+        body: JSON.stringify(body),
+      });
+      if (!resp.ok) {
+        let msg = `HTTP ${resp.status}`;
+        try {
+          const e = await resp.json();
+          if (e.error) msg = e.error;
+        } catch (_) {}
+        throw new Error(msg);
+      }
+      const result = await resp.json();
+      setStage("done");
+      onUploaded?.(result);
+    } catch (e) {
+      setError(String(e?.message || e));
+      setStage("preview");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // ── Styles ────────────────────────────────────────────────────
+  const dropArea = {
+    border: `2px dashed ${drag ? t.ac : t.bd}`,
+    borderRadius: 12,
+    padding: "32px 20px",
+    textAlign: "center",
+    color: t.txM,
+    background: drag ? `${t.ac}11` : t.bgS,
+    cursor: "pointer",
+    transition: "all .12s",
+  };
+  const field = {
+    width: "100%",
+    padding: "9px 12px",
+    borderRadius: 8,
+    border: `1px solid ${t.bd}`,
+    background: t.bgS,
+    color: t.tx,
+    fontSize: 14,
+    fontFamily: "inherit",
+    boxSizing: "border-box",
+  };
+  const labelStyle = {
+    display: "block",
+    fontSize: 11,
+    fontWeight: 700,
+    textTransform: "uppercase",
+    letterSpacing: ".06em",
+    color: t.txM,
+    marginBottom: 4,
+  };
+
+  if (stage === "done") {
+    return (
+      <div
+        style={{
+          padding: 18,
+          borderRadius: 10,
+          border: `1px solid ${t.ok}`,
+          background: `${t.ok}11`,
+          color: t.tx,
+        }}
+      >
+        ✅ Saved <strong>{editCompany}</strong>
+        {editRole ? ` — ${editRole}` : ""} to your vault.
+        <div style={{ marginTop: 8, fontSize: 12, color: t.txM }}>
+          This is now your default resume for job-match scoring.
+        </div>
+        <button
+          type="button"
+          onClick={reset}
+          style={{
+            marginTop: 10,
+            padding: "6px 12px",
+            borderRadius: 6,
+            border: `1px solid ${t.bd}`,
+            background: "transparent",
+            color: t.tx,
+            cursor: "pointer",
+            fontSize: 12,
+            fontFamily: "inherit",
+          }}
+        >
+          Add another resume
+        </button>
+      </div>
+    );
+  }
+
+  if (stage === "preview" || stage === "uploading") {
+    return (
+      <div>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            padding: "10px 14px",
+            background: t.bgS,
+            border: `1px solid ${t.bd}`,
+            borderRadius: 8,
+            marginBottom: 14,
+          }}
+        >
+          <span style={{ fontSize: 22 }}>📄</span>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div
+              style={{
+                fontWeight: 600,
+                color: t.tx,
+                fontSize: 13,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+              title={file?.name}
+            >
+              {file?.name}
+            </div>
+            <div style={{ fontSize: 11, color: t.txM }}>
+              {file?.size != null
+                ? `${(file.size / 1024).toFixed(0)} KB`
+                : ""}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={reset}
+            style={{
+              padding: "4px 10px",
+              borderRadius: 6,
+              border: `1px solid ${t.bd}`,
+              background: "transparent",
+              color: t.txS,
+              cursor: "pointer",
+              fontSize: 12,
+              fontFamily: "inherit",
+            }}
+          >
+            Change file
+          </button>
+        </div>
+
+        <div style={{ display: "grid", gap: 12 }}>
+          <div>
+            <label style={labelStyle}>Company</label>
+            <input
+              type="text"
+              value={editCompany}
+              onChange={(e) => setEditCompany(e.target.value)}
+              style={field}
+              placeholder="e.g. Anthropic"
+            />
+          </div>
+          <div>
+            <label style={labelStyle}>Role (optional)</label>
+            <input
+              type="text"
+              value={editRole}
+              onChange={(e) => setEditRole(e.target.value)}
+              style={field}
+              placeholder="e.g. Data Engineer"
+            />
+          </div>
+          <div>
+            <label style={labelStyle}>Submitted</label>
+            <input
+              type="date"
+              value={submittedAt}
+              onChange={(e) => setSubmittedAt(e.target.value)}
+              style={field}
+            />
+            <div style={{ fontSize: 11, color: t.txM, marginTop: 4 }}>
+              Defaults to the file's last-modified date.
+            </div>
+          </div>
+        </div>
+
+        {error && (
+          <div
+            style={{
+              marginTop: 12,
+              padding: "8px 12px",
+              borderRadius: 6,
+              background: "#fee",
+              color: "#900",
+              fontSize: 13,
+              border: "1px solid #f99",
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 14 }}>
+          <button
+            type="button"
+            onClick={save}
+            disabled={busy}
+            style={{
+              padding: "10px 18px",
+              borderRadius: 8,
+              border: `1px solid ${t.ac}`,
+              background: t.ac,
+              color: "#fff",
+              fontWeight: 600,
+              cursor: busy ? "wait" : "pointer",
+              fontFamily: "inherit",
+              fontSize: 14,
+            }}
+          >
+            {busy ? "Saving…" : "Save to vault"}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div
+        style={dropArea}
+        onClick={() => inputRef.current?.click()}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDrag(true);
+        }}
+        onDragLeave={() => setDrag(false)}
+        onDrop={onDrop}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") inputRef.current?.click();
+        }}
+      >
+        <div style={{ fontSize: 38, marginBottom: 8 }}>📤</div>
+        <div style={{ fontWeight: 600, color: t.tx, marginBottom: 4 }}>
+          Drop a PDF here, or click to pick one
+        </div>
+        <div style={{ fontSize: 12, color: t.txM }}>
+          Up to 10 MB · We'll auto-parse company + role from the filename
+        </div>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="application/pdf"
+          onChange={onPick}
+          style={{ display: "none" }}
+        />
+      </div>
+      {error && (
+        <div
+          style={{
+            marginTop: 12,
+            padding: "8px 12px",
+            borderRadius: 6,
+            background: "#fee",
+            color: "#900",
+            fontSize: 13,
+            border: "1px solid #f99",
+          }}
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/PinSetup.jsx
+++ b/frontend/src/components/PinSetup.jsx
@@ -1,0 +1,348 @@
+/**
+ * PinSetup — 4-to-8-digit PIN entry + confirm, OR skip with consent.
+ *
+ * PRD #89 Slice 3, Step 6.
+ *
+ * Two flows:
+ *
+ *   1. **Create a PIN** — primary path. POST /api/set-pin, then POST
+ *      /api/login (so step 7 has a valid cookie + CSRF before the final
+ *      profile commit).
+ *
+ *   2. **Skip for now** — requires explicit consent checkbox. POSTs
+ *      ``{skip_pin_acknowledged: true}`` to /api/profile. The dashboard
+ *      then surfaces <MissingPinBanner> until a PIN is set.
+ *
+ * Props:
+ *   t:           theme tokens
+ *   apiBase:     RENDER_API
+ *   authHeaders: () => {Authorization?: string}
+ *   csrfToken:   string (used for /api/set-pin which is auth-gated)
+ *   onPinSet():  fired after PIN + login both succeed
+ *   onSkip():    fired after the skip-consent path succeeds
+ *   onCsrfRefresh(csrf): fired after a fresh /api/login mints a new
+ *                        CSRF; the caller persists it to localStorage
+ *                        so subsequent step-7 commits work.
+ */
+import { useState } from "react";
+
+const MIN_LEN = 4;
+const MAX_LEN = 8;
+const NUMERIC = /^\d*$/;
+
+export function PinSetup({
+  t,
+  apiBase,
+  authHeaders,
+  csrfToken,
+  onPinSet,
+  onSkip,
+  onCsrfRefresh,
+}) {
+  const [mode, setMode] = useState("create"); // create | skip
+  const [pin, setPin] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [consent, setConsent] = useState(false);
+  const [error, setError] = useState(null);
+  const [busy, setBusy] = useState(false);
+
+  const valid =
+    pin.length >= MIN_LEN &&
+    pin.length <= MAX_LEN &&
+    NUMERIC.test(pin) &&
+    pin === confirm;
+
+  const save = async () => {
+    setError(null);
+    if (!valid) {
+      if (pin.length < MIN_LEN) setError(`PIN must be at least ${MIN_LEN} digits`);
+      else if (pin.length > MAX_LEN) setError(`PIN can't exceed ${MAX_LEN} digits`);
+      else if (!NUMERIC.test(pin)) setError("PIN must be numeric");
+      else if (pin !== confirm) setError("PINs don't match");
+      return;
+    }
+    setBusy(true);
+    try {
+      // Set the PIN — this endpoint is Bearer/cookie gated. In wizard
+      // first-run mode the API_SECRET is unset (dev) and this passes;
+      // in production setups it requires the existing session.
+      const setResp = await fetch(`${apiBase}/api/set-pin`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(csrfToken ? { "X-CSRF-Token": csrfToken } : {}),
+          ...(authHeaders ? authHeaders() : {}),
+        },
+        credentials: "include",
+        body: JSON.stringify({ pin }),
+      });
+      if (!setResp.ok) {
+        let msg = `HTTP ${setResp.status}`;
+        try {
+          const e = await setResp.json();
+          if (e.error) msg = e.error;
+        } catch (_) {}
+        throw new Error(msg);
+      }
+
+      // Immediately log in with the new PIN so step 7's profile commit
+      // has a fresh cookie + CSRF token. Without this, the next request
+      // would be unauthenticated and the wizard would dead-end.
+      const loginResp = await fetch(`${apiBase}/api/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ pin }),
+      });
+      if (loginResp.ok) {
+        try {
+          const d = await loginResp.json();
+          if (d.csrf_token) onCsrfRefresh?.(d.csrf_token);
+        } catch (_) {}
+      }
+
+      onPinSet?.();
+    } catch (e) {
+      setError(String(e?.message || e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const skipWithConsent = async () => {
+    if (!consent) {
+      setError(
+        "Please confirm you understand anyone with this URL can edit preferences."
+      );
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const resp = await fetch(`${apiBase}/api/profile`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(csrfToken ? { "X-CSRF-Token": csrfToken } : {}),
+          ...(authHeaders ? authHeaders() : {}),
+        },
+        credentials: "include",
+        body: JSON.stringify({ skip_pin_acknowledged: true }),
+      });
+      if (!resp.ok) {
+        let msg = `HTTP ${resp.status}`;
+        try {
+          const e = await resp.json();
+          if (e.error) msg = e.error;
+        } catch (_) {}
+        throw new Error(msg);
+      }
+      onSkip?.();
+    } catch (e) {
+      setError(String(e?.message || e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const tabBtn = (active, label, onClick) => (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        padding: "8px 16px",
+        borderRadius: 8,
+        border: `1px solid ${active ? t.ac : t.bd}`,
+        background: active ? t.ac : "transparent",
+        color: active ? "#fff" : t.tx,
+        fontSize: 13,
+        fontWeight: 600,
+        cursor: "pointer",
+        fontFamily: "inherit",
+      }}
+    >
+      {label}
+    </button>
+  );
+
+  const field = {
+    width: "100%",
+    padding: "11px 14px",
+    borderRadius: 8,
+    border: `1px solid ${t.bd}`,
+    background: t.bgS,
+    color: t.tx,
+    fontSize: 18,
+    fontFamily: "inherit",
+    letterSpacing: "0.3em",
+    textAlign: "center",
+    boxSizing: "border-box",
+  };
+
+  return (
+    <div>
+      <div style={{ display: "flex", gap: 8, marginBottom: 18 }}>
+        {tabBtn(mode === "create", "Create a PIN", () => setMode("create"))}
+        {tabBtn(mode === "skip", "Skip for now", () => setMode("skip"))}
+      </div>
+
+      {mode === "create" && (
+        <div>
+          <p style={{ color: t.txM, fontSize: 13, marginTop: 0 }}>
+            4 to 8 digits. The PIN gates write access to your preferences
+            and resume vault. It's stored as a pbkdf2 hash — recoverable
+            only by admin shell access.
+          </p>
+          <div style={{ display: "grid", gap: 12 }}>
+            <input
+              type="password"
+              inputMode="numeric"
+              maxLength={MAX_LEN}
+              autoComplete="new-password"
+              value={pin}
+              onChange={(e) => {
+                if (NUMERIC.test(e.target.value)) setPin(e.target.value);
+              }}
+              placeholder="PIN"
+              style={field}
+            />
+            <input
+              type="password"
+              inputMode="numeric"
+              maxLength={MAX_LEN}
+              autoComplete="new-password"
+              value={confirm}
+              onChange={(e) => {
+                if (NUMERIC.test(e.target.value)) setConfirm(e.target.value);
+              }}
+              placeholder="Confirm PIN"
+              style={field}
+            />
+          </div>
+          {error && (
+            <div
+              style={{
+                marginTop: 12,
+                padding: "8px 12px",
+                borderRadius: 6,
+                background: "#fee",
+                color: "#900",
+                fontSize: 13,
+                border: "1px solid #f99",
+              }}
+            >
+              {error}
+            </div>
+          )}
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "flex-end",
+              marginTop: 16,
+            }}
+          >
+            <button
+              type="button"
+              onClick={save}
+              disabled={!valid || busy}
+              style={{
+                padding: "11px 22px",
+                borderRadius: 8,
+                border: `1px solid ${valid ? t.ac : t.bd}`,
+                background: valid ? t.ac : t.bgS,
+                color: valid ? "#fff" : t.txM,
+                fontSize: 14,
+                fontWeight: 600,
+                cursor: valid && !busy ? "pointer" : "not-allowed",
+                fontFamily: "inherit",
+              }}
+            >
+              {busy ? "Saving…" : "Save PIN →"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {mode === "skip" && (
+        <div>
+          <div
+            style={{
+              padding: "12px 14px",
+              borderRadius: 8,
+              background: `${t.wm}11`,
+              border: `1px solid ${t.wm}`,
+              color: t.tx,
+              fontSize: 13,
+              marginBottom: 14,
+            }}
+          >
+            ⚠️ Without a PIN, anyone who knows the dashboard URL can
+            change your roles, dream companies, and resume vault.
+          </div>
+          <label
+            style={{
+              display: "flex",
+              alignItems: "flex-start",
+              gap: 10,
+              color: t.tx,
+              fontSize: 14,
+              cursor: "pointer",
+              padding: "8px 0",
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={consent}
+              onChange={(e) => setConsent(e.target.checked)}
+              style={{ marginTop: 3 }}
+            />
+            <span>
+              I understand anyone with this URL can edit my preferences.
+            </span>
+          </label>
+          {error && (
+            <div
+              style={{
+                marginTop: 12,
+                padding: "8px 12px",
+                borderRadius: 6,
+                background: "#fee",
+                color: "#900",
+                fontSize: 13,
+                border: "1px solid #f99",
+              }}
+            >
+              {error}
+            </div>
+          )}
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "flex-end",
+              marginTop: 16,
+            }}
+          >
+            <button
+              type="button"
+              onClick={skipWithConsent}
+              disabled={!consent || busy}
+              style={{
+                padding: "11px 22px",
+                borderRadius: 8,
+                border: `1px solid ${consent ? t.wm : t.bd}`,
+                background: consent ? t.wm : t.bgS,
+                color: consent ? "#fff" : t.txM,
+                fontSize: 14,
+                fontWeight: 600,
+                cursor: consent && !busy ? "pointer" : "not-allowed",
+                fontFamily: "inherit",
+              }}
+            >
+              {busy ? "Saving…" : "Skip without PIN →"}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/tabs/OnboardingWizard.jsx
+++ b/frontend/src/tabs/OnboardingWizard.jsx
@@ -15,6 +15,7 @@
 import { useEffect, useMemo, useReducer, useState } from "react";
 
 import { TH } from "../lib/theme.js";
+import { RENDER_API, authHeaders } from "../lib/api.js";
 import {
   TOTAL_STEPS,
   STEP_LABELS,
@@ -25,6 +26,13 @@ import {
 } from "../lib/wizard.js";
 import { ChipCloud } from "../components/ChipCloud.jsx";
 import { StepProgress } from "../components/StepProgress.jsx";
+// Slice 3 step components — replace the Step5/6 placeholders that
+// shipped with Slice 2.
+import { PdfDropzone } from "../components/PdfDropzone.jsx";
+import { PinSetup } from "../components/PinSetup.jsx";
+import { BulkUploadHelpCard } from "../components/BulkUploadHelpCard.jsx";
+
+const CSRF_LS_KEY = "jobscout_csrf";
 
 const BG_OVERLAY = "rgba(0,0,0,0.5)";
 
@@ -57,20 +65,44 @@ export function OnboardingWizard({ mode = "light", onComplete, onSkip }) {
   const canAdvanceStep2 =
     state.roles.length > 0 || state.customRoles.length > 0;
 
-  // ── Step-4 interim commit ────────────────────────────────────────
-  // PRD §2.7: at the end of step 4 in this slice, POST the collected
-  // state to /api/profile and onComplete the wizard. Slice 3 inserts
-  // steps 5/6 between step 4 and this commit; the consolidating step 7
-  // re-POSTs with the additional fields then.
-  const advanceFromStep4 = async () => {
+  // ── Step-7 final commit (Slice 3) ───────────────────────────────
+  // Slice 2 committed at the end of step 4; Slice 3 moves the commit
+  // to step 7 so default_resume_version + skip_pin_acknowledged are
+  // included in the same POST. Step 4 now just advances to step 5.
+  const finalCommit = async () => {
     dispatch({ type: "SAVE_START" });
     try {
-      await persistProfile(state, rosters.roles, { includeOnboardedAt: true });
+      await persistProfile(state, rosters.roles, {
+        includeOnboardedAt: true,
+        ...(state.uploadedResumeVersion
+          ? { defaultResumeVersion: state.uploadedResumeVersion }
+          : {}),
+        ...(state.skipPinAcknowledged
+          ? { skipPinAcknowledged: true }
+          : {}),
+      });
       dispatch({ type: "SAVE_OK" });
       onComplete?.();
     } catch (e) {
       dispatch({ type: "SAVE_FAIL", message: String(e?.message || e) });
     }
+  };
+
+  // Read the CSRF token live so step 6's /api/login refresh propagates
+  // without re-rendering the wizard.
+  const getCsrf = () => {
+    if (typeof window === "undefined") return "";
+    try {
+      return window.localStorage.getItem(CSRF_LS_KEY) || "";
+    } catch {
+      return "";
+    }
+  };
+  const setCsrf = (csrf) => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(CSRF_LS_KEY, csrf);
+    } catch {}
   };
 
   // Skip path from Step 1 — sets onboarded_at to the sentinel "preview".
@@ -455,22 +487,81 @@ export function OnboardingWizard({ mode = "light", onComplete, onSkip }) {
           </>
         )}
 
-        {/* ─── Step 5: Resume Vault (Slice 3 fills this in) ─── */}
+        {/* ─── Step 5: Resume Vault (Slice 3) ─── */}
         {state.step === 5 && (
-          <Step5Placeholder
-            t={t}
-            onBack={() => dispatch({ type: "BACK" })}
-            onSkip={() => dispatch({ type: "NEXT" })}
-          />
+          <>
+            <h1 style={heading}>Add a resume</h1>
+            <p style={sub}>
+              Drop a single PDF to set as your default — or skip to the
+              CLI helper below for bulk-uploading a folder.
+            </p>
+            <PdfDropzone
+              t={t}
+              apiBase={RENDER_API}
+              authHeaders={authHeaders}
+              csrfToken={getCsrf()}
+              onUploaded={(result) => {
+                if (result?.version_key) {
+                  dispatch({
+                    type: "SET_UPLOADED_RESUME",
+                    versionKey: result.version_key,
+                  });
+                }
+              }}
+            />
+            <div style={{ marginTop: 24 }}>
+              <BulkUploadHelpCard
+                t={t}
+                apiBase={RENDER_API}
+                apiToken={
+                  typeof window !== "undefined"
+                    ? window.localStorage.getItem("vault_token") || ""
+                    : ""
+                }
+              />
+            </div>
+            <FooterNav
+              t={t}
+              onBack={() => dispatch({ type: "BACK" })}
+              onNext={() => dispatch({ type: "NEXT" })}
+              nextLabel={
+                state.uploadedResumeVersion ? "Continue →" : "Skip for now →"
+              }
+            />
+          </>
         )}
 
-        {/* ─── Step 6: PIN (Slice 3 fills this in) ─── */}
+        {/* ─── Step 6: PIN (Slice 3) ─── */}
         {state.step === 6 && (
-          <Step6Placeholder
-            t={t}
-            onBack={() => dispatch({ type: "BACK" })}
-            onSkip={() => dispatch({ type: "NEXT" })}
-          />
+          <>
+            <h1 style={heading}>Set a PIN</h1>
+            <p style={sub}>
+              Protects your preferences from anyone else who has this
+              dashboard URL. You can change or remove it later from the
+              Monitor tab.
+            </p>
+            <PinSetup
+              t={t}
+              apiBase={RENDER_API}
+              authHeaders={authHeaders}
+              csrfToken={getCsrf()}
+              onPinSet={() => {
+                dispatch({ type: "SET_PIN_SET" });
+                dispatch({ type: "NEXT" });
+              }}
+              onSkip={() => {
+                dispatch({ type: "SET_SKIP_PIN_ACK" });
+                dispatch({ type: "NEXT" });
+              }}
+              onCsrfRefresh={(csrf) => setCsrf(csrf)}
+            />
+            <FooterNav
+              t={t}
+              onBack={() => dispatch({ type: "BACK" })}
+              onNext={() => dispatch({ type: "NEXT" })}
+              nextLabel="Skip step →"
+            />
+          </>
         )}
 
         {/* ─── Step 7: Done ─── */}
@@ -487,7 +578,7 @@ export function OnboardingWizard({ mode = "light", onComplete, onSkip }) {
                 type="button"
                 style={btnPrimary}
                 disabled={state.saving}
-                onClick={advanceFromStep4}
+                onClick={finalCommit}
               >
                 {state.saving ? "Saving…" : "Go to dashboard →"}
               </button>
@@ -497,11 +588,6 @@ export function OnboardingWizard({ mode = "light", onComplete, onSkip }) {
       </div>
     </div>
   );
-
-  // Helper for steps that fall into the "primary commit" path. Step 4
-  // in Slice 2 calls advanceFromStep4 instead of NEXT so we land at the
-  // dashboard. Slice 3 will rewire step 4 to dispatch NEXT and let the
-  // commit run from step 7.
 }
 
 /* ─── Footer nav ─────────────────────────────────────────────────── */
@@ -568,58 +654,3 @@ function FooterNav({ t, onBack, onNext, nextDisabled, nextHint, nextLabel }) {
   );
 }
 
-/* ─── Step 5/6 placeholders (Slice 3 replaces) ──────────────────── */
-
-function Step5Placeholder({ t, onBack, onSkip }) {
-  return (
-    <>
-      <h1
-        style={{
-          fontFamily: "'Playfair Display', serif",
-          fontSize: 28,
-          margin: "8px 0 4px",
-        }}
-      >
-        Add a resume
-      </h1>
-      <p style={{ color: t.txM, fontSize: 14, marginBottom: 20 }}>
-        Drag a PDF here or skip for now. Adding a resume lets JobScout
-        score every job against it. (Slice 3 ships the drag-drop UI;
-        for now, the Vault tab in the dashboard handles uploads.)
-      </p>
-      <FooterNav
-        t={t}
-        onBack={onBack}
-        onNext={onSkip}
-        nextLabel="Skip for now →"
-      />
-    </>
-  );
-}
-
-function Step6Placeholder({ t, onBack, onSkip }) {
-  return (
-    <>
-      <h1
-        style={{
-          fontFamily: "'Playfair Display', serif",
-          fontSize: 28,
-          margin: "8px 0 4px",
-        }}
-      >
-        Set a PIN
-      </h1>
-      <p style={{ color: t.txM, fontSize: 14, marginBottom: 20 }}>
-        Optional — protects who can change your preferences. (Slice 3
-        ships the PIN entry UI; you can set one later from the
-        ⚙️ Settings panel.)
-      </p>
-      <FooterNav
-        t={t}
-        onBack={onBack}
-        onNext={onSkip}
-        nextLabel="Skip for now →"
-      />
-    </>
-  );
-}


### PR DESCRIPTION
Implements **Slice 3 of 4** of the First-Run Onboarding Wizard PRD (#89, tracking issue #92). The two heaviest wizard steps plus the small backend endpoint that powers the dropzone preview.

## Dependency

⚠️ Depends on **#98 (Slice 1)** + **#99 (Slice 2)**. This PR's diff includes their commits as ancestors — when they merge, this PR rebases cleanly to just the Slice 3 deltas.

## What this lands

### Backend
**`POST /api/vault/parse-filename`** — echo of `parse_resume_filename()` for the wizard's drag-drop preview. Pure function, no DB write, no PII, microsecond cost. Auth-exempt via path whitelist in `_vault_require_auth` so the wizard can preview the parser's output **before** the user has a session.

```json
POST /api/vault/parse-filename
{"filename": "Narendranath_GS_DE.pdf"}
→ 200 {"company": "Goldman Sachs", "role": "Data Engineer",
       "version_key": "gs_de", "display_name": "...", "extension": "pdf"}
```

Tests: 10 new in `test_vault_parse_filename.py` pinning shape, validation (empty / whitespace / oversize), and both no-auth + Bearer-auth code paths.

### Frontend components (4 new)

| Component | Purpose |
|---|---|
| `PdfDropzone.jsx` | Drag-drop or click-to-pick PDF. FileReader base64-encode, parse-filename preview with editable {company, role, submitted_at} fields, posts to `/api/vault/upload` with CSRF + Bearer fallback. Defaults `submitted_at` to `file.lastModified` per PRD. |
| `PinSetup.jsx` | Tabbed Create-PIN vs Skip flow. Create: 4-8 numeric digits + confirm, calls `/api/set-pin` then **immediately** `/api/login` so step 7's commit has a fresh cookie + CSRF. Skip: required consent checkbox, posts `{skip_pin_acknowledged: true}`. |
| `BulkUploadHelpCard.jsx` | Path B static panel with the `bulk_upload_to_render.py` invocation inlined with the user's actual API URL. Refresh-vault button polls `/api/vault/stats`. |
| `MissingPinBanner.jsx` | Permanent yellow banner shown when `has_pin == false && skip_pin_acknowledged == true`. Click → enters `/setup?force=1&step=6` to set a PIN. Self-decides whether to render. |

### Wizard wiring (`tabs/OnboardingWizard.jsx`)
- Step 5 now uses `<PdfDropzone>` + `<BulkUploadHelpCard>` instead of the Slice 2 placeholder. On successful upload, dispatches `SET_UPLOADED_RESUME` so the final commit can mark it default.
- Step 6 now uses `<PinSetup>`. On PIN-set: dispatches `SET_PIN_SET` and advances. On skip: dispatches `SET_SKIP_PIN_ACK` and advances. CSRF token from `/api/login` persisted to `localStorage["jobscout_csrf"]` so step 7's commit has it.
- Step 4's interim `/api/profile` POST moved to step 7 (`finalCommit`) so `default_resume_version` + `skip_pin_acknowledged` land in the same call.
- Removed `Step5Placeholder` and `Step6Placeholder` shims that shipped with Slice 2.

### App.jsx
- Full `/api/profile` response now cached in `profile` state (was: just `default_resume_version`).
- `<MissingPinBanner t={t} profile={profile} />` mounted at the top of the dashboard chrome — renders only when the user opted out of PIN during onboarding.
- Wizard `onComplete` refetches `/api/profile` so the banner appears immediately if PIN was skipped.

## Acceptance criteria (issue #92)

- [x] Step 5 drag-drop: dropping a PDF previews parsed Company/Role with editable fields; "Save" creates the vault entry with the user's edits + correct `submitted_at` from `file.lastModified`
- [x] Step 5 Path B: copy block uses the user's actual API URL; "Refresh vault" updates the visible count
- [x] Step 6 Create: PIN length validation (4-8 numeric); mismatched confirm surfaces inline error; on success the cookie is set (via auto `/api/login` after `/api/set-pin`) so step 7 doesn't 401
- [x] Step 6 Skip path requires explicit consent checkbox; on save, `skip_pin_acknowledged = 1`
- [x] `MissingPinBanner` shows on every page load when no PIN is set and skip was acknowledged
- [x] Final commit on step 7 includes all wizard state (roles + companies + locations + comp + default_resume_version + onboarded_at)
- [x] `POST /api/vault/parse-filename` returns the documented shape; rejects empty + oversize inputs

## Build verification

Backend: **233 passing** (was 223; +10 parse-filename tests).
Frontend: `vite v5.4 build` clean, 855 modules, 712 kB bundle.

## Open questions resolved here

- **Q4 (zip upload)** — NOT added. Path B sticks with the CLI per PRD default.

## Out of scope (Slice 4)

- Login screen for returning users (PR #97)
- Read-only preview enforcement (PR #97)
- "Reset onboarding" admin button (PR #97)
- Discord ping for typed-but-unscraped companies (PR #97)

Closes #92.

https://claude.ai/code/session_013oPBxo3hVTuMDKwbLtm3Rb

---
_Generated by [Claude Code](https://claude.ai/code/session_013oPBxo3hVTuMDKwbLtm3Rb)_