### PR TITLE
fix(auth): multi-worker session key drift — file-backed shared key + prod hard-fail

### DIFF
--- a/backend/routes/_auth.py
+++ b/backend/routes/_auth.py
@@ -73,11 +73,19 @@ _PRODUCTION_ENV_FLAGS = (
     ("DYNO", None),                        # Heroku sets DYNO=web.1 etc.
 )
 
-# Default location for the shared fallback key. ``/tmp`` is world-writable
-# and survives across forked workers but NOT across machine reboots — fine
-# because cookies invalidating after a reboot is acceptable dev behaviour.
-# Operators can override via SESSION_KEY_FILE to pin a more durable path.
-_DEFAULT_KEY_FILE = os.path.join(tempfile.gettempdir(), "jobscout-session-key")
+# Default location for the shared fallback key. ``~/.jobscout/session-key``
+# beats the previous ``/tmp/jobscout-session-key`` on two counts:
+#   1. ``/tmp`` is world-writable — a local unprivileged user could
+#      pre-create the path as a symlink to a file they own; the chmod
+#      0600 then applies to *their* file and the rename follows the
+#      symlink (the parent dir is what matters).
+#   2. ``/tmp`` is typically tmpfs and gets cleaned at boot. Stored
+#      under the home dir, the key survives reboots so local-dev
+#      sessions don't invalidate every morning.
+# Operators can override via SESSION_KEY_FILE to pin a different path
+# (e.g. ``/var/lib/jobscout/session.key`` for system-wide installs).
+_DEFAULT_KEY_DIR = os.path.expanduser("~/.jobscout")
+_DEFAULT_KEY_FILE = os.path.join(_DEFAULT_KEY_DIR, "session-key")
 
 # Process-local memoisation so we don't re-read the key file on every
 # request. Guarded by a lock so concurrent first-touch from multiple
@@ -144,7 +152,15 @@ def _load_or_create_fallback_key() -> str:
         new_key = secrets.token_hex(32)
         try:
             dir_ = os.path.dirname(path) or "."
-            os.makedirs(dir_, exist_ok=True)
+            # mode=0o700 on the dir prevents the symlink-pre-creation
+            # attack: even if the path inside is world-writable on the
+            # filesystem, the parent dir restricts who can stat/list/
+            # cd into it. Existing dirs keep their permissions.
+            os.makedirs(dir_, mode=0o700, exist_ok=True)
+            try:
+                os.chmod(dir_, 0o700)
+            except OSError:
+                pass  # best-effort on non-POSIX
             fd, tmp_path = tempfile.mkstemp(
                 prefix=".jobscout-session-key.", dir=dir_
             )
@@ -181,17 +197,26 @@ def _load_or_create_fallback_key() -> str:
             except OSError:
                 pass
         except OSError as e:
-            log.error(
-                "could not persist session key to %s: %s — falling back to "
-                "process-local key (sessions will not survive worker fork)",
-                path, e,
-            )
+            # No silent process-local fallback here — that would re-
+            # introduce the multi-worker bug this whole function exists
+            # to fix. If we can't persist the key, the operator MUST
+            # know via a hard failure rather than via random 401s in
+            # production logs days later. Raise with a remediation
+            # pointer so the cause is obvious from the traceback.
+            raise RuntimeError(
+                f"auth: could not persist session key to {path}: {e}. "
+                "Set SESSION_KEY_FILE to a writable path or export "
+                "SESSION_SECRET_KEY directly to skip the file-backed "
+                "fallback entirely."
+            ) from e
 
-        # Last-ditch fallback: process-local key. This restores the OLD
-        # broken behaviour, but only if the filesystem is unwritable
-        # (e.g. a read-only container). Logged loudly so operators see it.
-        _FALLBACK_KEY_CACHE = new_key
-        return new_key
+        # Defensive: if we reach here without returning a key, raise
+        # rather than caching None. Shouldn't be possible given the
+        # branching above, but make the failure mode explicit.
+        raise RuntimeError(
+            f"auth: session key file at {path} ended up empty after "
+            "atomic write — refusing to mint per-worker keys"
+        )
 
 
 def _fallback_key() -> str:

--- a/backend/routes/_auth.py
+++ b/backend/routes/_auth.py
@@ -16,8 +16,17 @@ PRD #89 Slice 1. Three auth modes the dashboard + bulk uploader use:
 The signed cookie uses ``itsdangerous.URLSafeTimedSerializer`` — Flask's
 own session signing primitive, transitive dep, no new package. Signature
 key precedence: ``SESSION_SECRET_KEY`` env → ``API_SECRET`` env →
-process-local random fallback (cookies invalidate on each restart in
-dev, which is fine).
+file-backed shared fallback (multi-worker safe in dev; production hard-
+fails if neither env var is set).
+
+Multi-worker safety: under gunicorn's pre-fork model each forked worker
+imports modules fresh, so a ``secrets.token_hex()`` generated at import
+time would yield a DIFFERENT key per worker. A user logs in on worker 1
+and the next request hits worker 2 → signature check fails → random
+401s under load. The fallback key is therefore persisted to a shared
+file (``SESSION_KEY_FILE`` env, default ``/tmp/jobscout-session-key``)
+written atomically by the first worker and read by the rest, so every
+worker signs and verifies with the same key.
 
 API surface — every route blueprint should call ``require_auth(request)``
 instead of hand-rolling its own ``_check_auth``. Returns:
@@ -31,6 +40,8 @@ import logging
 import os
 import re
 import secrets
+import tempfile
+import threading
 import time
 from typing import Optional, Tuple
 
@@ -50,10 +61,154 @@ SESSION_MAX_AGE_SECONDS = 30 * 24 * 60 * 60
 
 _BEARER_RE = re.compile(r"^Bearer\s+(\S+)\s*$", re.IGNORECASE)
 
-# Per-process fallback signing key so a dev server without
-# SESSION_SECRET_KEY or API_SECRET still works (cookies invalidate on
-# restart, which is the expected dev-mode behaviour).
-_FALLBACK_KEY = secrets.token_hex(32)
+# Env vars that flag this process as running in production. Any one being
+# truthy means "production" — when neither SESSION_SECRET_KEY nor
+# API_SECRET is set in that mode, we hard-fail rather than silently
+# minting a fallback key (which under multi-worker gunicorn would give
+# every worker its own key and cause random session invalidation).
+_PRODUCTION_ENV_FLAGS = (
+    ("JOBSCOUT_ENV", ("production", "prod")),
+    ("FLASK_ENV", ("production", "prod")),
+    ("RENDER", ("true", "1", "yes")),     # Render sets RENDER=true
+    ("DYNO", None),                        # Heroku sets DYNO=web.1 etc.
+)
+
+# Default location for the shared fallback key. ``/tmp`` is world-writable
+# and survives across forked workers but NOT across machine reboots — fine
+# because cookies invalidating after a reboot is acceptable dev behaviour.
+# Operators can override via SESSION_KEY_FILE to pin a more durable path.
+_DEFAULT_KEY_FILE = os.path.join(tempfile.gettempdir(), "jobscout-session-key")
+
+# Process-local memoisation so we don't re-read the key file on every
+# request. Guarded by a lock so concurrent first-touch from multiple
+# threads doesn't race the file write.
+_FALLBACK_KEY_CACHE: Optional[str] = None
+_FALLBACK_KEY_LOCK = threading.Lock()
+
+
+def _is_production() -> bool:
+    """Truthy when any production-marker env var is set."""
+    for name, truthy_vals in _PRODUCTION_ENV_FLAGS:
+        val = os.environ.get(name, "").strip().lower()
+        if not val:
+            continue
+        if truthy_vals is None:
+            return True  # presence alone is enough (DYNO)
+        if val in truthy_vals:
+            return True
+    return False
+
+
+def _key_file_path() -> str:
+    """Resolve the shared fallback key file path (env-overridable)."""
+    return os.environ.get("SESSION_KEY_FILE", "").strip() or _DEFAULT_KEY_FILE
+
+
+def _load_or_create_fallback_key() -> str:
+    """Read the shared fallback key from disk, generating + persisting it
+    on first call. Multi-worker safe: each worker that races to create
+    the file uses an atomic rename so the last writer wins without
+    leaving a partial file visible to readers, and any worker that finds
+    the file already populated reads the existing key.
+
+    Cached in module state after the first successful read so the file
+    is touched at most once per worker process.
+    """
+    global _FALLBACK_KEY_CACHE
+    if _FALLBACK_KEY_CACHE is not None:
+        return _FALLBACK_KEY_CACHE
+
+    with _FALLBACK_KEY_LOCK:
+        # Re-check after acquiring the lock in case another thread won.
+        if _FALLBACK_KEY_CACHE is not None:
+            return _FALLBACK_KEY_CACHE
+
+        path = _key_file_path()
+
+        # Fast path: file already exists from a previous worker / start.
+        try:
+            with open(path, "r", encoding="ascii") as fh:
+                existing = fh.read().strip()
+            if existing and len(existing) >= 32:
+                _FALLBACK_KEY_CACHE = existing
+                return existing
+        except FileNotFoundError:
+            pass
+        except OSError as e:  # pragma: no cover — defensive
+            log.warning("could not read session key file %s: %s", path, e)
+
+        # Slow path: generate a new key and persist it atomically. We
+        # write to a temp file in the same directory then rename — POSIX
+        # rename is atomic so concurrent workers either see the old file
+        # (none) or the new file (complete), never a half-written one.
+        new_key = secrets.token_hex(32)
+        try:
+            dir_ = os.path.dirname(path) or "."
+            os.makedirs(dir_, exist_ok=True)
+            fd, tmp_path = tempfile.mkstemp(
+                prefix=".jobscout-session-key.", dir=dir_
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="ascii") as fh:
+                    fh.write(new_key)
+                # Restrict to owner — the key is sensitive.
+                try:
+                    os.chmod(tmp_path, 0o600)
+                except OSError:
+                    pass  # best-effort on non-POSIX
+                os.replace(tmp_path, path)
+            except Exception:
+                # Clean up tmp file if rename failed.
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
+
+            # Re-read after rename in case another worker beat us — we
+            # want every worker to converge on the same value.
+            try:
+                with open(path, "r", encoding="ascii") as fh:
+                    final_key = fh.read().strip()
+                if final_key and len(final_key) >= 32:
+                    _FALLBACK_KEY_CACHE = final_key
+                    log.warning(
+                        "auth: using file-backed fallback signing key at %s — "
+                        "set SESSION_SECRET_KEY in production",
+                        path,
+                    )
+                    return final_key
+            except OSError:
+                pass
+        except OSError as e:
+            log.error(
+                "could not persist session key to %s: %s — falling back to "
+                "process-local key (sessions will not survive worker fork)",
+                path, e,
+            )
+
+        # Last-ditch fallback: process-local key. This restores the OLD
+        # broken behaviour, but only if the filesystem is unwritable
+        # (e.g. a read-only container). Logged loudly so operators see it.
+        _FALLBACK_KEY_CACHE = new_key
+        return new_key
+
+
+def _fallback_key() -> str:
+    """Return the fallback signing key, hard-failing in production.
+
+    In production (any of JOBSCOUT_ENV / FLASK_ENV / RENDER / DYNO set),
+    a missing SESSION_SECRET_KEY *and* missing API_SECRET is a config
+    error — silently generating a key would cause random logouts as
+    workers cycle. Raise loudly so the operator sees it at startup.
+    """
+    if _is_production():
+        raise RuntimeError(
+            "auth: refusing to mint a fallback signing key in production. "
+            "Set SESSION_SECRET_KEY (preferred) or API_SECRET in the "
+            "environment so all gunicorn workers share the same key."
+        )
+    return _load_or_create_fallback_key()
 
 # State-changing methods that require CSRF for cookie auth. GET/HEAD/
 # OPTIONS are exempt because they're considered safe per RFC 7231 §4.2.1
@@ -67,12 +222,19 @@ def _signing_key() -> str:
     Read live so pytest fixtures that ``monkeypatch.setenv`` take effect
     without re-importing. The microsecond cost is negligible compared
     to the SQLite + IO work that follows every authenticated request.
+
+    Precedence:
+      1. ``SESSION_SECRET_KEY`` (explicit, recommended for production)
+      2. ``API_SECRET`` (re-used so single-secret deployments still work)
+      3. Shared file-backed fallback (dev only — see ``_fallback_key``)
     """
-    return (
+    explicit = (
         os.environ.get("SESSION_SECRET_KEY", "").strip()
         or os.environ.get("API_SECRET", "").strip()
-        or _FALLBACK_KEY
     )
+    if explicit:
+        return explicit
+    return _fallback_key()
 
 
 def _api_secret() -> str:

--- a/backend/tests/test_auth_cookie.py
+++ b/backend/tests/test_auth_cookie.py
@@ -435,3 +435,69 @@ def test_pre_existing_key_file_is_reused(tmp_path, monkeypatch):
     assert read_session(cookie) is not None
     # File content unchanged.
     assert key_file.read_text() == preseeded
+
+
+# ─── Critic-flagged hardening ──────────────────────────────────────────────
+
+
+def test_fallback_key_raises_on_unwritable_filesystem(tmp_path, monkeypatch):
+    """If the key file can't be persisted, we MUST raise, not silently
+    fall back to a process-local key. Silent fallback re-introduces the
+    multi-worker bug this function was written to fix.
+
+    Forces the failure by monkeypatching ``os.makedirs`` to raise —
+    direct filesystem-perm tests don't work as root (Docker/CI). The
+    interesting behaviour is the exception-handling branch, not how
+    we got there.
+    """
+    from routes import _auth as auth
+
+    monkeypatch.setenv("SESSION_KEY_FILE", str(tmp_path / "wont-be-created" / "key"))
+    monkeypatch.delenv("SESSION_SECRET_KEY", raising=False)
+    monkeypatch.delenv("API_SECRET", raising=False)
+    _reset_fallback_cache()
+
+    real_makedirs = os.makedirs
+
+    def boom_on_jobscout_dir(path, *a, **kw):
+        if "wont-be-created" in str(path):
+            raise OSError(13, "Permission denied")
+        return real_makedirs(path, *a, **kw)
+
+    monkeypatch.setattr(os, "makedirs", boom_on_jobscout_dir)
+
+    import pytest as _pytest
+    with _pytest.raises(RuntimeError, match=r"could not persist session key"):
+        auth._load_or_create_fallback_key()
+
+    # Cache must NOT have been populated with a process-local key —
+    # this is the regression guard against the previous silent fallback.
+    assert auth._FALLBACK_KEY_CACHE is None
+
+
+def test_default_key_dir_is_under_home_not_tmp():
+    """Predictable /tmp paths invite symlink-pre-creation attacks.
+
+    The default key file must live under ~/.jobscout/, not anywhere a
+    local unprivileged user could plant a symlink before first start.
+    """
+    from routes import _auth as auth
+    assert auth._DEFAULT_KEY_FILE.startswith(os.path.expanduser("~/.jobscout"))
+    assert "tmp" not in auth._DEFAULT_KEY_FILE.lower()
+
+
+def test_default_key_dir_created_with_restrictive_perms(tmp_path, monkeypatch):
+    """First-use of the default dir creates it 0o700, not 0o755."""
+    from routes import _auth as auth
+
+    custom = tmp_path / "subdir" / "session-key"
+    monkeypatch.setenv("SESSION_KEY_FILE", str(custom))
+    monkeypatch.delenv("SESSION_SECRET_KEY", raising=False)
+    monkeypatch.delenv("API_SECRET", raising=False)
+    _reset_fallback_cache()
+
+    auth._load_or_create_fallback_key()
+    # The parent dir we just created should be 0o700.
+    parent = custom.parent
+    mode = parent.stat().st_mode & 0o777
+    assert mode == 0o700, f"key dir perms = {oct(mode)} (expected 0o700)"

--- a/backend/tests/test_auth_cookie.py
+++ b/backend/tests/test_auth_cookie.py
@@ -271,3 +271,167 @@ def test_cookie_signed_with_session_secret_key(monkeypatch):
     payload = read_session(cookie_a)
     assert payload is not None
     assert "csrf" in payload
+
+
+# ─── Multi-worker fallback key (regression for random-401s bug) ────────────
+
+def _reset_fallback_cache():
+    """Helper: clear the module-level fallback key cache so subsequent
+    calls hit the file (or generate fresh). Mirrors what a freshly-forked
+    gunicorn worker sees on its first auth request."""
+    import routes._auth as auth
+    auth._FALLBACK_KEY_CACHE = None
+
+
+def test_fallback_key_is_shared_across_workers(tmp_path, monkeypatch):
+    """Two simulated worker processes (cleared module cache) must derive
+    the SAME fallback key from the shared file — a cookie signed by one
+    must verify on the other. Pre-fix this failed because each worker
+    generated its own random ``secrets.token_hex(32)`` at import time.
+    """
+    from routes._auth import issue_session, read_session
+
+    # Force dev mode + a writable, isolated key file.
+    monkeypatch.delenv("SESSION_SECRET_KEY", raising=False)
+    monkeypatch.delenv("API_SECRET", raising=False)
+    monkeypatch.delenv("JOBSCOUT_ENV", raising=False)
+    monkeypatch.delenv("FLASK_ENV", raising=False)
+    monkeypatch.delenv("RENDER", raising=False)
+    monkeypatch.delenv("DYNO", raising=False)
+    key_file = tmp_path / "session.key"
+    monkeypatch.setenv("SESSION_KEY_FILE", str(key_file))
+
+    # Worker A starts cold, mints a session.
+    _reset_fallback_cache()
+    cookie, _csrf = issue_session()
+    assert key_file.exists(), "first worker should have persisted the key"
+    key_a = key_file.read_text().strip()
+    assert len(key_a) >= 32
+
+    # Worker B starts cold and tries to verify worker A's cookie.
+    _reset_fallback_cache()
+    payload = read_session(cookie)
+    assert payload is not None, (
+        "second worker rejected the first worker's cookie — fallback key "
+        "is not being shared across forked workers"
+    )
+    assert "csrf" in payload
+
+    # And the file content didn't change (B read, didn't overwrite).
+    assert key_file.read_text().strip() == key_a
+
+
+def test_production_mode_hard_fails_without_secret(monkeypatch, tmp_path):
+    """In production, neither SESSION_SECRET_KEY nor API_SECRET set must
+    raise immediately rather than silently mint a per-worker key."""
+    from routes._auth import issue_session
+    import routes._auth as auth
+
+    monkeypatch.delenv("SESSION_SECRET_KEY", raising=False)
+    monkeypatch.delenv("API_SECRET", raising=False)
+    monkeypatch.setenv("SESSION_KEY_FILE", str(tmp_path / "k"))
+    monkeypatch.setenv("JOBSCOUT_ENV", "production")
+    _reset_fallback_cache()
+
+    with pytest.raises(RuntimeError, match="fallback signing key in production"):
+        issue_session()
+
+    # Cleanup: drop the prod flag so later tests aren't affected.
+    monkeypatch.delenv("JOBSCOUT_ENV", raising=False)
+    _reset_fallback_cache()
+
+
+def test_production_with_session_secret_key_works(monkeypatch, tmp_path):
+    """Production mode is fine as long as SESSION_SECRET_KEY is set —
+    the hard-fail is only the fallback path, not every prod request."""
+    from routes._auth import issue_session, read_session
+
+    monkeypatch.delenv("API_SECRET", raising=False)
+    monkeypatch.setenv("SESSION_SECRET_KEY", "prod-key-xyz")
+    monkeypatch.setenv("JOBSCOUT_ENV", "production")
+    monkeypatch.setenv("SESSION_KEY_FILE", str(tmp_path / "k"))
+    _reset_fallback_cache()
+
+    cookie, _csrf = issue_session()
+    assert read_session(cookie) is not None
+
+
+def test_production_with_api_secret_only_works(monkeypatch, tmp_path):
+    """API_SECRET alone (legacy single-secret deployments) is also fine
+    in production — it satisfies the explicit-key requirement."""
+    from routes._auth import issue_session, read_session
+
+    monkeypatch.delenv("SESSION_SECRET_KEY", raising=False)
+    monkeypatch.setenv("API_SECRET", "legacy-prod-secret")
+    monkeypatch.setenv("JOBSCOUT_ENV", "production")
+    monkeypatch.setenv("SESSION_KEY_FILE", str(tmp_path / "k"))
+    _reset_fallback_cache()
+
+    cookie, _csrf = issue_session()
+    assert read_session(cookie) is not None
+
+
+def test_render_env_flag_triggers_production(monkeypatch, tmp_path):
+    """RENDER=true (set by Render automatically) must trip the prod check."""
+    from routes._auth import issue_session
+
+    monkeypatch.delenv("SESSION_SECRET_KEY", raising=False)
+    monkeypatch.delenv("API_SECRET", raising=False)
+    monkeypatch.delenv("JOBSCOUT_ENV", raising=False)
+    monkeypatch.setenv("RENDER", "true")
+    monkeypatch.setenv("SESSION_KEY_FILE", str(tmp_path / "k"))
+    _reset_fallback_cache()
+
+    with pytest.raises(RuntimeError):
+        issue_session()
+
+    monkeypatch.delenv("RENDER", raising=False)
+    _reset_fallback_cache()
+
+
+def test_fallback_key_file_permissions_restricted(tmp_path, monkeypatch):
+    """The persisted fallback key file must not be world-readable —
+    cookies signed with a leaked key can be forged."""
+    import stat
+    from routes._auth import issue_session
+
+    monkeypatch.delenv("SESSION_SECRET_KEY", raising=False)
+    monkeypatch.delenv("API_SECRET", raising=False)
+    monkeypatch.delenv("JOBSCOUT_ENV", raising=False)
+    monkeypatch.delenv("RENDER", raising=False)
+    key_file = tmp_path / "perm-test.key"
+    monkeypatch.setenv("SESSION_KEY_FILE", str(key_file))
+    _reset_fallback_cache()
+
+    issue_session()
+    mode = stat.S_IMODE(os.stat(key_file).st_mode)
+    # Owner read/write only — no group or other access.
+    assert mode & stat.S_IRWXG == 0, f"group bits set: {oct(mode)}"
+    assert mode & stat.S_IRWXO == 0, f"world bits set: {oct(mode)}"
+
+
+def test_pre_existing_key_file_is_reused(tmp_path, monkeypatch):
+    """If the key file already exists (e.g. left from a previous run or
+    written by the parent gunicorn process), workers must read it
+    verbatim instead of overwriting."""
+    from routes._auth import issue_session, read_session, _load_or_create_fallback_key
+
+    monkeypatch.delenv("SESSION_SECRET_KEY", raising=False)
+    monkeypatch.delenv("API_SECRET", raising=False)
+    monkeypatch.delenv("JOBSCOUT_ENV", raising=False)
+    monkeypatch.delenv("RENDER", raising=False)
+    monkeypatch.delenv("DYNO", raising=False)
+    key_file = tmp_path / "preseeded.key"
+    preseeded = "a" * 64  # 64 hex chars
+    key_file.write_text(preseeded)
+    monkeypatch.setenv("SESSION_KEY_FILE", str(key_file))
+    _reset_fallback_cache()
+
+    loaded = _load_or_create_fallback_key()
+    assert loaded == preseeded
+
+    # And cookies sign/verify with this preseeded key.
+    cookie, _ = issue_session()
+    assert read_session(cookie) is not None
+    # File content unchanged.
+    assert key_file.read_text() == preseeded


### PR DESCRIPTION
Fixes a real multi-worker bug in `routes/_auth.py` introduced by Slice 1 (PR #98): `_FALLBACK_KEY = secrets.token_hex(32)` ran once per Python import, so under gunicorn's pre-fork model each worker minted a different signing key. A cookie signed by worker 1 fails verification on worker 2 — random 401 logouts in production.

Surfaced by the Phase-2 critic head-to-head pass (4/5 critics picked this approach).

## Fix

**File-backed shared key + production hard-fail (hybrid).**

1. **Dev mode** (no production env flag detected) → fallback key persists at `~/.jobscout/session-key` (overridable via `SESSION_KEY_FILE`). Parent dir created with mode `0o700` to prevent the symlink-pre-creation attack the previous `/tmp/jobscout-session-key` default was vulnerable to. Atomic `os.replace()` write means concurrent workers either see the old file (none) or the new file (complete), never a half-written one. After first read, the key is module-cached.

2. **Production mode** (`JOBSCOUT_ENV=production`, `FLASK_ENV=production`, `RENDER=true`, or `DYNO` set) → `RuntimeError` raised at first `_signing_key()` call if neither `SESSION_SECRET_KEY` nor `API_SECRET` is configured. Operator sees the failure on first request, not as a mystery 401 storm in production logs days later.

3. **Both env vars set** → behaves exactly as before. No file touched.

## Critic-flagged tweaks baked in

- ✅ Silent `OSError` fallback replaced with `raise` — if we can't persist the key, we MUST fail loud (silent fallback would re-introduce the bug this fixes)
- ✅ Default key path moved from `/tmp/jobscout-session-key` to `~/.jobscout/session-key` with `0o700` parent (symlink-attack guard)
- ✅ 3 new regression tests: fail-loud on persist failure, default-path-not-under-`/tmp`, parent-dir-mode-0o700

## Tests

- **23 passing** in `test_auth_cookie.py` (was 20)
- Test names: `test_fallback_key_is_shared_across_workers`, `test_production_mode_hard_fails_without_secret`, `test_fallback_key_raises_on_unwritable_filesystem`, `test_default_key_dir_is_under_home_not_tmp`, `test_default_key_dir_created_with_restrictive_perms`, + 4 more

## Known deferral

- Test simulates workers by clearing module cache in same process — not a true `multiprocessing.Process` fork. Documented as TODO; the file-backed mechanism is correct, but a true forked-process test would be a stronger regression guard.

## Why this is its own PR (not bundled into a Slice)

Per cross-cutting Phase-2 critic: this bug exists TODAY in `main` after PR #98 landed, independent of the wizard. A separate PR against `main` is the right shape so it can ship faster than another wizard slice would.

https://claude.ai/code/session_013oPBxo3hVTuMDKwbLtm3Rb

---
_Generated by [Claude Code](https://claude.ai/code/session_013oPBxo3hVTuMDKwbLtm3Rb)_