### PR TITLE
fix(wizard): handle /api/profile 401/403 — first-run user on PIN-gated deploy now sees the wizard

### DIFF
--- a/frontend/node_modules/.package-lock.json
+++ b/frontend/node_modules/.package-lock.json
@@ -295,6 +295,23 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
@@ -368,6 +385,32 @@
       "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.58.0.tgz",
+      "integrity": "sha512-ZjMyby5SICi227y1MTR3VYBpFTdZs823Rs/hpakufleBoufoOIB6jtm9FEoxn/cgO7l6PM2rCEl5Kre5vX0QrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.58.0",
@@ -1171,6 +1214,20 @@
         "@rollup/rollup-win32-x64-msvc": "4.58.0",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.58.0.tgz",
+      "integrity": "sha512-+410Srdoh78MKSJxTQ+hZ/Mx+ajd6RjjPwBPNd0R3J9FtL6ZA0GqiiyNjCO9In0IzZkCNrpGymSfn+kgyPQocg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/scheduler": {
       "version": "0.23.2",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -364,15 +364,31 @@ export default function App() {
   // ── Onboarding wizard gate (PRD #89 Slice 2) ─────────────────────
   // First-run detection runs once on mount once Render is configured.
   // Possible states:
-  //   "loading" — probe in flight
-  //   "first-run" — show wizard (blocking)
-  //   "force"    — ?force=1 / /setup path → show wizard
+  //   "loading"        — probe in flight
+  //   "first-run"      — show wizard (blocking)
+  //   "force"          — ?force=1 / /setup path → show wizard
+  //   "login-required" — /api/profile returned 401/403; we can't tell
+  //                      first-run vs onboarded until the user logs in.
+  //                      Render a login affordance (Slice 4 LoginScreen,
+  //                      or the SetupPanel fallback below) and re-probe
+  //                      via redetectOnboarding() once auth succeeds.
   //   "onboarded" / "unknown" — render dashboard normally
   // The wizard's onComplete callback flips this to "onboarded" without
   // re-probing, so a successful completion doesn't bounce the user.
   const [onboardingState, setOnboardingState] = useState(
     RENDER_API ? "loading" : "unknown"
   );
+  // Re-runnable detection — Slice 4's LoginScreen will call this from
+  // its onSuccess handler so the dashboard transitions straight into
+  // the wizard (or skips it) without a full page reload.
+  const redetectOnboarding = useCallback(() => {
+    if (!RENDER_API) {
+      setOnboardingState("unknown");
+      return;
+    }
+    setOnboardingState("loading");
+    detectOnboardingState().then((s) => setOnboardingState(s));
+  }, []);
   useEffect(() => {
     if (!RENDER_API) {
       setOnboardingState("unknown");
@@ -388,6 +404,11 @@ export default function App() {
   }, []);
   const wizardActive =
     onboardingState === "first-run" || onboardingState === "force";
+  // PIN/Bearer-protected deployment with no valid credentials yet. The
+  // wizard MUST stay hidden here — we genuinely don't know whether the
+  // user is first-run or already onboarded. Slice 4 will replace this
+  // banner with a proper LoginScreen.
+  const loginRequired = onboardingState === "login-required";
 
   // Best-match vault integration on job cards
   const [bestMatchByJob, setBestMatchByJob] = useState({});
@@ -1810,6 +1831,55 @@ export default function App() {
             }
           }}
         />
+      )}
+      {loginRequired && !setupOpen && (
+        // Stand-in for Slice 4's <LoginScreen>. The wizard can't render
+        // (we don't know if first-run yet) and the dashboard would be
+        // useless without an auth token, so block with a banner that
+        // points the user at the SetupPanel for token entry. When Slice 4
+        // lands, swap this for <LoginScreen onSuccess={redetectOnboarding} />.
+        <div role="dialog" aria-modal="true" aria-labelledby="login-required-title"
+          style={{
+            position:"fixed", inset:0, background:"rgba(0,0,0,0.6)", zIndex:9998,
+            display:"flex", alignItems:"center", justifyContent:"center", padding:"20px",
+          }}>
+          <div style={{
+            background:t.cd, color:t.tx, border:`1px solid ${t.bd}`, borderRadius:14,
+            padding:"28px", maxWidth:480, width:"100%",
+            boxShadow:t.shL || "0 12px 40px rgba(0,0,0,0.35)",
+            fontFamily:"inherit",
+          }}>
+            <h2 id="login-required-title" style={{
+              margin:"0 0 10px", fontSize:20, fontWeight:700,
+              fontFamily:"'Playfair Display',serif",
+            }}>
+              🔒 Login required
+            </h2>
+            <p style={{margin:"0 0 18px", fontSize:14, color:t.txM, lineHeight:1.55}}>
+              Your JobScout server is PIN/token protected. Sign in to
+              continue — the dashboard needs your profile before it can
+              decide whether to show the onboarding wizard.
+            </p>
+            <div style={{display:"flex", gap:10, justifyContent:"flex-end", flexWrap:"wrap"}}>
+              <button type="button" onClick={redetectOnboarding}
+                style={{
+                  padding:"10px 16px", borderRadius:8, fontSize:14, fontWeight:600,
+                  cursor:"pointer", fontFamily:"inherit", border:`1px solid ${t.bd}`,
+                  background:"transparent", color:t.txM,
+                }}>
+                Retry
+              </button>
+              <button type="button" onClick={() => setSetupOpen(true)}
+                style={{
+                  padding:"10px 16px", borderRadius:8, fontSize:14, fontWeight:600,
+                  cursor:"pointer", fontFamily:"inherit", border:"none",
+                  background:t.gP || t.ac, color:"#fff",
+                }}>
+                Open server settings
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
       <div className="page-pad">

--- a/frontend/src/lib/wizard.js
+++ b/frontend/src/lib/wizard.js
@@ -75,7 +75,20 @@ export async function detectOnboardingState() {
       return "login-required";
     }
 
-    if (!profileResp.ok) return "unknown";
+    if (!profileResp.ok) {
+      // 5xx (server error) or 4xx-other (resource not found, schema
+      // change). Both leave us unable to decide first-run vs onboarded.
+      // We deliberately fall back to "unknown" rather than "first-run"
+      // because a server blip should NOT relaunch the wizard for a
+      // user who already onboarded. The trade-off: a TRUE first-run
+      // user on a flaky server might silently skip the wizard. The
+      // console.warn surfaces this in DevTools so it's debuggable.
+      console.warn(
+        `wizard: /api/profile returned ${profileResp.status} — ` +
+          `skipping wizard. If this is a fresh install, use /setup?force=1.`
+      );
+      return "unknown";
+    }
     const profile = await profileResp.json();
 
     // onboarded_at is the explicit completion marker. Set by the wizard

--- a/frontend/src/lib/wizard.js
+++ b/frontend/src/lib/wizard.js
@@ -25,11 +25,19 @@ import { RENDER_API, authHeaders } from "./api.js";
  * user has used the dashboard before and skip the wizard.
  *
  * Returns one of:
- *   "first-run"  — show the wizard (blocking)
- *   "force"      — URL says ?force=1 or path /setup, show wizard
- *   "onboarded"  — skip wizard, render dashboard normally
- *   "unknown"    — API call failed; fall back to onboarded (don't
- *                  block users behind a broken probe)
+ *   "first-run"      — show the wizard (blocking)
+ *   "force"          — URL says ?force=1 or path /setup, show wizard
+ *   "onboarded"      — skip wizard, render dashboard normally
+ *   "login-required" — server is PIN-protected and we have no valid
+ *                      Bearer/cookie; caller should prompt for login
+ *                      (Slice 4 LoginScreen) and re-detect on success
+ *   "unknown"        — probe failed for an unrelated reason (network,
+ *                      5xx); fall back to onboarded so a flaky server
+ *                      doesn't permanently block the user
+ *
+ * The probe sends ``credentials: "include"`` + ``authHeaders()`` so an
+ * already-authenticated visitor (Bearer in localStorage OR a valid
+ * session cookie) is recognised and never sees the login prompt.
  */
 export async function detectOnboardingState() {
   // Path / query short-circuits — always win over the API probe so
@@ -45,13 +53,27 @@ export async function detectOnboardingState() {
   try {
     const [profileResp, vaultResp] = await Promise.all([
       fetch(`${RENDER_API}/api/profile`, {
+        headers: { ...authHeaders() },
+        credentials: "include",
         signal: AbortSignal.timeout(8000),
       }),
       fetch(`${RENDER_API}/api/vault/stats`, {
         headers: { ...authHeaders() },
+        credentials: "include",
         signal: AbortSignal.timeout(8000),
       }),
     ]);
+
+    // 401/403 on the profile probe means the server is auth-gated and
+    // we have no valid credentials yet. We CANNOT decide first-run vs
+    // onboarded without reading the profile, so the caller has to log
+    // the user in first and re-run this probe. Returning a distinct
+    // sentinel (instead of "unknown") prevents the old bug where a
+    // brand-new user behind a PIN-protected deployment silently
+    // skipped the wizard.
+    if (profileResp.status === 401 || profileResp.status === 403) {
+      return "login-required";
+    }
 
     if (!profileResp.ok) return "unknown";
     const profile = await profileResp.json();


### PR DESCRIPTION
Fixes a silent-skip bug in the wizard's first-run detection added by Slice 2 (PR #99). Previously, `wizard.js::detectOnboardingState()` treated `/api/profile` `401` / `403` as `"unknown"` → falling through to `"onboarded"`. Result: a brand-new user on a PIN-gated deploy never saw the wizard, because the auth gate rejected the probe before any decision could be made.

Surfaced by Phase-2 critic head-to-head pass (4/5 picked this approach).

## Fix

**Add a `"login-required"` sentinel.** When `/api/profile` returns 401 or 403, `detectOnboardingState()` now returns `"login-required"` instead of `"unknown"`. App.jsx renders a blocking login modal in that state until the user authenticates, then re-runs the probe.

The blocking modal is intentionally minimal styling (will polish in a later pass when the LoginScreen primitives from Slice 4 are refactored).

## Critic-flagged tweaks baked in

- ✅ **5xx tightening** (`wizard.js:78`) — the legacy `"unknown" → "onboarded"` silent skip remains for 5xx server errors (intentional: a server blip should NOT relaunch the wizard for an already-onboarded user). But a `console.warn` now surfaces the status + a hint about `/setup?force=1` so the silent skip is debuggable from DevTools.
- The full `redetectOnboarding` after SetupPanel close is deferred — that requires cross-component plumbing and is documented as a known minor gap (user can reload).

## Critic-rejected alternative

The B-attempt design ("local-first deferred sync queue", ~340 LOC) was a more ambitious approach that wrote `localStorage["jobscout_wizard_complete"]` and queued failed POSTs to retry later. Critic rejected it because:

- `if (!RENDER_API) return "first-run"` reintroduced its own bug (wizard launches against a backend that doesn't exist → Step 4 throws → user stuck)
- Network error returns `"onboarded"` → flaky network silently skips the wizard
- Cross-device divergence is real and unmitigated (complete in Chrome, see wizard again in Firefox)
- `flushPendingProfile()` was dead code — depends on a Slice-4 LoginScreen integration that didn't exist when the agent wrote it

Pick A is ~96 LOC; B is ~340 LOC for an inferior outcome.

## Files

- `frontend/src/lib/wizard.js` — `"login-required"` sentinel, 5xx warning
- `frontend/src/App.jsx` — login modal mount when state is `"login-required"`

## Build

`vite v5.4` build clean.

https://claude.ai/code/session_013oPBxo3hVTuMDKwbLtm3Rb

---
_Generated by [Claude Code](https://claude.ai/code/session_013oPBxo3hVTuMDKwbLtm3Rb)_