### PR TITLE
fix(auth): CSRF on /api/logout + Origin guard for Bearer-from-browser

### DIFF
--- a/backend/routes/_auth.py
+++ b/backend/routes/_auth.py
@@ -327,6 +327,89 @@ def _bearer_matches(request) -> bool:
     )
 
 
+def _bearer_request_is_safe(request) -> bool:
+    """Guard the "Bearer skips CSRF" path against XSS-via-localStorage.
+
+    Threat: an XSS payload in the dashboard can read
+    ``localStorage["vault_token"]`` and then issue ``Authorization:
+    Bearer ...`` requests. Because Bearer auth bypasses CSRF (the
+    standard design — machine clients have no cookies to protect), an
+    attacker who exfiltrated only the token can mount fully-authorised
+    cross-site writes. The cookie CSRF check is useless here.
+
+    Defence: when a Bearer request also carries a browser-set ``Origin``
+    or ``Sec-Fetch-Site`` header, require the ``Origin`` to be in
+    ``ALLOWED_ORIGINS``. Browsers set ``Origin`` on all cross-origin
+    POST / PUT / PATCH / DELETE (and on same-origin POST too in
+    practice); curl / Python ``requests`` / the ``bulk_upload_to_render``
+    CLI do not, so the legitimate machine-to-machine path is unaffected.
+
+    Rules:
+      * No ``Origin`` AND no ``Sec-Fetch-Site`` → CLI / proxy caller →
+        pass.
+      * ``Origin`` present and matches one of ``ALLOWED_ORIGINS`` →
+        legitimate browser caller (dashboard itself) → pass.
+      * ``Origin`` present and ``ALLOWED_ORIGINS`` unset → dev / single-
+        origin deploy → pass with a one-time WARN log so operators set
+        the allowlist before production.
+      * ``Origin`` present but NOT in the allowlist → likely XSS or
+        cross-site abuse → reject.
+
+    Safe methods (GET / HEAD / OPTIONS) are exempt; they can't be
+    weaponised for state changes anyway.
+    """
+    if request.method not in _STATE_CHANGING_METHODS:
+        return True
+
+    origin = request.headers.get("Origin", "").strip()
+    sec_fetch_site = request.headers.get("Sec-Fetch-Site", "").strip()
+
+    # Pure machine caller — neither header present.
+    if not origin and not sec_fetch_site:
+        return True
+
+    # Browser caller. If the deploy hasn't configured an allowlist,
+    # we degrade to "warn but allow" so dev workflows don't break;
+    # production operators get a loud log line to fix it.
+    allowed = _allowed_origins()
+    if not allowed:
+        if not _bearer_request_is_safe._warned_no_allowlist:  # type: ignore[attr-defined]
+            log.warning(
+                "Bearer request from browser context (Origin=%r) but "
+                "ALLOWED_ORIGINS is unset — set it in production to block "
+                "XSS-via-localStorage Bearer forgery",
+                origin or "<missing>",
+            )
+            _bearer_request_is_safe._warned_no_allowlist = True  # type: ignore[attr-defined]
+        return True
+
+    if origin and origin in allowed:
+        return True
+
+    log.warning(
+        "Bearer request rejected: Origin=%r not in ALLOWED_ORIGINS (browser "
+        "context detected via Origin or Sec-Fetch-Site header)",
+        origin or "<missing>",
+    )
+    return False
+
+
+# Initialise the one-time-warn flag as a function attribute. Cheaper
+# than a module global with a lock — re-entrance is fine, we just
+# don't want to spam the log on every request.
+_bearer_request_is_safe._warned_no_allowlist = False  # type: ignore[attr-defined]
+
+
+def _allowed_origins() -> list[str]:
+    """Resolve ALLOWED_ORIGINS live so operator-changed values take effect
+    without restart (matches the rest of this module's live-env pattern).
+    """
+    raw = os.environ.get("ALLOWED_ORIGINS", "").strip()
+    if not raw:
+        return []
+    return [o.strip() for o in raw.split(",") if o.strip()]
+
+
 def _cookie_matches(request) -> Optional[dict]:
     """Return the decoded session payload when the cookie is valid."""
     return read_session(request.cookies.get(SESSION_COOKIE_NAME, ""))
@@ -358,9 +441,16 @@ def require_auth(request) -> Optional[Tuple[dict, int]]:
     Auth rules:
 
     * Dev mode (``API_SECRET`` unset) → always pass.
-    * Bearer token matches → pass (no CSRF check; non-browser caller).
+    * Bearer token matches:
+        * If the request is a state-changing method AND has a browser-set
+          ``Origin`` / ``Sec-Fetch-Site`` header, the Origin must be in
+          ``ALLOWED_ORIGINS`` (defence against XSS-via-localStorage
+          Bearer forgery — see ``_bearer_request_is_safe``).
+        * Otherwise → pass (machine-to-machine caller, e.g. the bulk
+          uploader).
     * Valid session cookie + (safe method OR matching CSRF header) → pass.
-    * Otherwise → 401 (no auth at all) or 403 (cookie ok, CSRF missing).
+    * Otherwise → 401 (no auth at all) or 403 (cookie ok, CSRF missing,
+      or Bearer from blocked origin).
     """
     # Dev mode bypass — preserves the existing local-dev workflow where
     # nobody sets API_SECRET and every endpoint is open.
@@ -368,6 +458,8 @@ def require_auth(request) -> Optional[Tuple[dict, int]]:
         return None
 
     if _bearer_matches(request):
+        if not _bearer_request_is_safe(request):
+            return ({"error": "origin_not_allowed"}, 403)
         return None
 
     session = _cookie_matches(request)

--- a/backend/routes/profile_routes.py
+++ b/backend/routes/profile_routes.py
@@ -272,14 +272,50 @@ def api_login():
 
 @profile_bp.route("/api/logout", methods=["POST", "OPTIONS"])
 def api_logout():
-    """Clear the session cookie. Always returns 200 — idempotent.
+    """Clear the session cookie. Idempotent on success.
 
-    No CSRF check: clearing a cookie is not a state-changing operation
-    on server-side data, and refusing logout on a missing token would
-    just trap users in a broken session.
+    CSRF gate: logout DOES require a valid CSRF token (or a Bearer
+    token from an approved origin) — without it, a hostile site could
+    auto-submit ``<form action="/api/logout">`` and silently log out
+    every JobScout user that visits. Annoying-but-not-catastrophic is
+    still a UX denial-of-service we can cheaply prevent. The earlier
+    no-CSRF stance was wrong (per Phase-2 critic, systemic miss B).
+
+    Three valid auth shapes:
+      * Unauthenticated (no cookie, no Bearer) → 200 no-op so a stale
+        client trying to "clean up" doesn't 401-loop. No cookie is
+        cleared because there was nothing to clear.
+      * Cookie + matching ``X-CSRF-Token`` → 200, cookie cleared.
+      * Bearer + (no browser-Origin, OR Origin in allowlist) → 200,
+        cookie cleared (covers ``bulk_upload_to_render.py`` flows
+        that may stash a stale cookie).
     """
     if request.method == "OPTIONS":
         return "", 204
+
+    has_cookie = bool(request.cookies.get("jobscout_session", ""))
+    has_bearer = bool(request.headers.get("Authorization", "").strip())
+
+    # No auth at all → idempotent. Still emit the Set-Cookie clear
+    # header in case the browser has a session cookie that wasn't sent
+    # this request (different cookie-jar, SameSite weirdness) so the
+    # public contract — "after /api/logout, no jobscout_session
+    # cookie remains" — holds even on the no-auth path.
+    if not has_cookie and not has_bearer:
+        return jsonify({"status": "logged_out"}), 200, {
+            "Access-Control-Allow-Origin": "*",
+            **clear_session_cookie_headers(),
+        }
+
+    # Some form of auth present → apply the full gate so the CSRF /
+    # Origin checks run. Failure here returns 403 so the client knows
+    # the request was rejected (cookie / Bearer still valid server-
+    # side).
+    deny = require_auth(request)
+    if deny is not None:
+        body, status = deny
+        return jsonify(body), status, {"Access-Control-Allow-Origin": "*"}
+
     headers = {
         "Access-Control-Allow-Origin": "*",
         **clear_session_cookie_headers(),

--- a/backend/tests/test_auth_cookie.py
+++ b/backend/tests/test_auth_cookie.py
@@ -573,3 +573,176 @@ def test_wizard_bootstrap_path_works_under_pin_gated_deploy(client):
     body = login_resp.get_json()
     assert "csrf_token" in body
     assert "jobscout_session=" in login_resp.headers.get("Set-Cookie", "")
+
+
+# ─── /api/logout CSRF gate (systemic miss B) ──────────────────────────────
+
+
+def test_logout_with_cookie_and_csrf_clears(client_with_pin):
+    """Authenticated session + matching CSRF → logout succeeds and the
+    server emits a Max-Age=0 Set-Cookie."""
+    _cookie, csrf = _login_and_extract(client_with_pin, "1234")
+    resp = client_with_pin.post(
+        "/api/logout", headers={"X-CSRF-Token": csrf}
+    )
+    assert resp.status_code == 200
+    set_cookie = resp.headers.get("Set-Cookie", "")
+    assert "jobscout_session=" in set_cookie
+    assert "Max-Age=0" in set_cookie
+
+
+def test_logout_with_cookie_no_csrf_returns_403(client_with_pin):
+    """The reason this PR exists: a cross-site `<form action=/api/logout>`
+    will send the cookie but not the CSRF header. Pre-fix this returned
+    200 and the user was silently logged out. Now it MUST 403.
+    """
+    _login_and_extract(client_with_pin, "1234")
+    resp = client_with_pin.post("/api/logout")  # no CSRF header
+    assert resp.status_code == 403
+    assert resp.get_json()["error"] == "csrf_token_invalid"
+
+
+def test_logout_with_cookie_wrong_csrf_returns_403(client_with_pin):
+    """Attacker-supplied / stale CSRF → 403."""
+    _login_and_extract(client_with_pin, "1234")
+    resp = client_with_pin.post(
+        "/api/logout", headers={"X-CSRF-Token": "wrong-token-xxx"}
+    )
+    assert resp.status_code == 403
+
+
+def test_logout_with_bearer_no_browser_origin_clears(client_with_pin):
+    """Bearer-from-CLI (no Origin / Sec-Fetch-Site) → logout works
+    without CSRF. Covers bulk_upload_to_render.py edge cases."""
+    resp = client_with_pin.post(
+        "/api/logout", headers={"Authorization": f"Bearer {SECRET}"}
+    )
+    assert resp.status_code == 200
+    assert "Max-Age=0" in resp.headers.get("Set-Cookie", "")
+
+
+def test_logout_no_auth_at_all_is_idempotent(client_with_pin):
+    """Stale client trying to "clean up" with neither cookie nor Bearer
+    must not 401-loop. Returns 200 + Set-Cookie clear so the contract
+    "no jobscout_session after logout" holds defensively."""
+    # Fresh test client — no cookie jar, no previous login.
+    import server
+    with server.app.test_client() as fresh:
+        resp = fresh.post("/api/logout")
+        assert resp.status_code == 200
+        assert "Max-Age=0" in resp.headers.get("Set-Cookie", "")
+
+
+# ─── Bearer-from-browser Origin guard (systemic miss B) ───────────────────
+
+
+def test_bearer_without_origin_passes(client_with_pin, monkeypatch):
+    """Pure CLI caller (Python requests / curl) → no Origin / Sec-Fetch-
+    Site header → must pass. This is the bulk_upload_to_render.py path."""
+    monkeypatch.setenv("ALLOWED_ORIGINS", "https://dashboard.example.com")
+    from io import BytesIO
+    resp = client_with_pin.post(
+        "/api/vault/upload",
+        headers={"Authorization": f"Bearer {SECRET}"},
+        data={
+            "company": "TestCo", "role": "DE",
+            "file": (BytesIO(_MIN_PDF), "test.pdf"),
+        },
+        content_type="multipart/form-data",
+    )
+    # NOT 401 / 403 — the legitimate machine-to-machine path.
+    assert resp.status_code not in {401, 403}
+
+
+def test_bearer_from_allowed_origin_passes(client_with_pin, monkeypatch):
+    """Dashboard's own Bearer request (Origin in allowlist) → pass.
+    Pre-fix this was unconditional; post-fix we explicitly verify the
+    matching-origin branch."""
+    monkeypatch.setenv("ALLOWED_ORIGINS", "https://dashboard.example.com")
+    from io import BytesIO
+    resp = client_with_pin.post(
+        "/api/vault/upload",
+        headers={
+            "Authorization": f"Bearer {SECRET}",
+            "Origin": "https://dashboard.example.com",
+        },
+        data={
+            "company": "TestCo", "role": "DE",
+            "file": (BytesIO(_MIN_PDF), "test.pdf"),
+        },
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code not in {401, 403}
+
+
+def test_bearer_from_blocked_origin_returns_403(client_with_pin, monkeypatch):
+    """The core fix: an XSS that read localStorage["vault_token"] and
+    forges a Bearer request from a hostile site will carry the hostile
+    Origin. Reject."""
+    monkeypatch.setenv("ALLOWED_ORIGINS", "https://dashboard.example.com")
+    from io import BytesIO
+    resp = client_with_pin.post(
+        "/api/vault/upload",
+        headers={
+            "Authorization": f"Bearer {SECRET}",
+            "Origin": "https://attacker.example.com",
+        },
+        data={
+            "company": "TestCo", "role": "DE",
+            "file": (BytesIO(_MIN_PDF), "test.pdf"),
+        },
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 403
+    assert resp.get_json()["error"] == "origin_not_allowed"
+
+
+def test_bearer_from_browser_no_allowlist_warns_but_allows(
+    client_with_pin, monkeypatch, caplog
+):
+    """When ALLOWED_ORIGINS is unset (single-origin dev / pre-prod
+    deploy), the guard degrades to warn-but-allow so existing setups
+    don't break. Operators get a one-time log line to fix it."""
+    monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
+    # Reset the one-time-warn flag so this test gets a fresh log line.
+    from routes import _auth
+    _auth._bearer_request_is_safe._warned_no_allowlist = False
+
+    from io import BytesIO
+    with caplog.at_level("WARNING"):
+        resp = client_with_pin.post(
+            "/api/vault/upload",
+            headers={
+                "Authorization": f"Bearer {SECRET}",
+                "Origin": "https://anywhere.example.com",
+            },
+            data={
+                "company": "TestCo", "role": "DE",
+                "file": (BytesIO(_MIN_PDF), "test.pdf"),
+            },
+            content_type="multipart/form-data",
+        )
+    # Request goes through.
+    assert resp.status_code not in {401, 403}
+    # Warning emitted.
+    assert any(
+        "ALLOWED_ORIGINS is unset" in r.getMessage() for r in caplog.records
+    ), "expected one-time warn log; got: " + repr([r.getMessage() for r in caplog.records])
+
+
+def test_bearer_safe_method_with_blocked_origin_still_allowed(
+    client_with_pin, monkeypatch
+):
+    """Safe methods (GET / HEAD / OPTIONS) can't be weaponised for state
+    changes; the Origin guard explicitly exempts them so a malicious
+    Origin reading public data still works (and isn't a security issue —
+    the data is public)."""
+    monkeypatch.setenv("ALLOWED_ORIGINS", "https://dashboard.example.com")
+    resp = client_with_pin.get(
+        "/api/vault/list",
+        headers={
+            "Authorization": f"Bearer {SECRET}",
+            "Origin": "https://attacker.example.com",
+        },
+    )
+    assert resp.status_code not in {401, 403}

--- a/frontend/src/lib/auth.js
+++ b/frontend/src/lib/auth.js
@@ -80,18 +80,29 @@ export function shouldShowLogin(profile) {
 }
 
 /**
- * Logout: clear local session state and POST /api/logout.
+ * Logout: POST /api/logout (with CSRF) and clear local session state.
  *
- * Tolerates network failure — local state still clears so the user
- * lands on the LoginScreen on the next page load.
+ * Order matters: capture the CSRF token BEFORE clearing local state,
+ * send it with the request, THEN clear. The server-side
+ * ``/api/logout`` route now requires a matching CSRF header for
+ * cookie-authed requests (defence against cross-site form-submit
+ * logout DoS) — clearing first would make our own request 403.
+ *
+ * Tolerates network failure: local state still clears in the
+ * ``finally`` so the user lands on the LoginScreen on next page load.
  */
 export async function logout(apiBase) {
-  clearCsrf();
-  if (!apiBase) return;
+  const csrf = getCsrf();
   try {
+    if (!apiBase) return;
     await fetch(`${apiBase}/api/logout`, {
       method: "POST",
+      headers: csrf ? { "X-CSRF-Token": csrf } : {},
       credentials: "include",
     });
-  } catch (_) {}
+  } catch (_) {
+    /* swallow — local cleanup still runs below */
+  } finally {
+    clearCsrf();
+  }
 }


### PR DESCRIPTION
Closes systemic miss **B** from the Phase-2 cross-cutting critic (the second of three). Two related cookie-auth defects on the wizard's auth surface.

## What's broken

### 1. `/api/logout` had no CSRF gate

`POST /api/logout` was explicitly documented as no-CSRF on the rationale that "logout doesn't change server state". That's false — it changes the user's *session* state. A malicious cross-site `<form action="https://jobscout.example/api/logout" method="POST">` auto-submitted on any page silently logged out every JobScout user that visits. Annoying, not catastrophic, but trivially preventable.

### 2. Bearer auth bypassed CSRF entirely

The model was "machine clients have no cookies, so Bearer skips CSRF". True for curl / Python `requests`. **False for the dashboard itself** — it uses Bearer auth via `localStorage["vault_token"]` for `/api/vault/upload`. An XSS payload that can read localStorage can forge fully-authorised Bearer requests from any origin. Every CSRF gate becomes irrelevant.

## Fix

### Logout
`routes/profile_routes.py::api_logout` now routes through `require_auth`. Three valid paths:

| Caller | Auth | Result |
|---|---|---|
| Browser with valid session | Cookie + matching `X-CSRF-Token` | 200 + Set-Cookie clear |
| Browser missing/wrong CSRF | Cookie + no/bad CSRF | **403** `csrf_token_invalid` |
| CLI / approved Origin | Bearer | 200 + Set-Cookie clear |
| No auth at all | nothing | 200 idempotent no-op (defensive Set-Cookie clear so the public contract "no `jobscout_session` after logout" holds without 401-looping stale clients) |

Frontend `lib/auth.js::logout()` reordered: capture CSRF → fetch with header → clear local state in `finally`. Clearing first would have 403'd the client's own request.

### Bearer Origin guard
New `routes/_auth._bearer_request_is_safe(request)` inside `require_auth`. When a Bearer-authed request uses a state-changing method (POST/PUT/PATCH/DELETE) AND carries a browser-set `Origin` / `Sec-Fetch-Site` header, the Origin must be in `ALLOWED_ORIGINS`.

| Caller | Has Origin? | Allowlist set? | Origin in allowlist? | Result |
|---|---|---|---|---|
| `bulk_upload_to_render.py`, curl | No | any | n/a | ✅ pass (preserves CLI behaviour exactly) |
| Dashboard | Yes | yes | yes | ✅ pass |
| XSS / cross-site attacker | Yes | yes | no | ❌ 403 `origin_not_allowed` |
| Dev / single-origin deploy | Yes | no | n/a | ⚠️ pass with one-time WARN log (don't break existing setups) |

Safe methods (GET/HEAD/OPTIONS) are explicitly exempt — they can't be weaponised for state changes.

## Tests

`test_auth_cookie.py`: **36 passing** (was 26).

10 new tests — 5 for logout CSRF, 5 for Bearer Origin guard. Full backend suite: **279 passing** (was 269). Frontend: `vite v5.4` build clean.

## What this does NOT change

- `bulk_upload_to_render.py` — sends no Origin header, identical behaviour.
- Cookie-auth flows that were already correct (vault upload, profile POST, etc).
- The Bearer-token storage mechanism on the frontend (still `localStorage["vault_token"]`) — the right long-term fix is httpOnly cookies, but that's a larger refactor. This PR caps the blast radius of the existing storage choice.

## Context

This is the **second of three** systemic misses the Phase-2 critique identified after the wizard merged. The first (roster cache thread-safety) shipped via #106. The third (multi-worker module-level state propagation) is a wider design discussion still open.

https://claude.ai/code/session_013oPBxo3hVTuMDKwbLtm3Rb

---
_Generated by [Claude Code](https://claude.ai/code/session_013oPBxo3hVTuMDKwbLtm3Rb)_