### PR TITLE
Add dream company ranking and score breakdown visualization

### DIFF
--- a/frontend/src/components/JobCard.jsx
+++ b/frontend/src/components/JobCard.jsx
@@ -39,6 +39,8 @@ import {
   likelySponsor,
   jobFitTone,
   stopProp,
+  getDreamRank,
+  estimateScoreBreakdown,
 } from "../lib/jobConstants.js";
 import { LogoImg } from "./LogoImg.jsx";
 import { Pill } from "./Pill.jsx";
@@ -61,12 +63,12 @@ function _JobCard({
   onFetchBestMatch,
   onToggleVersionRow,
   onDownloadResumePdf,
-  rank,
 }) {
   const sc = j.relevance_score || 0;
   const ats = ATS_META[j.ats] || ATS_META.unknown;
   const catLbl = ROLE_CATS.find(r => r.id === j._cat)?.label || "Other";
   const isApplied = j.application_status === 'applied';
+  const dreamRank = getDreamRank(j.company);
 
   const cardStyle = {
     background:t.cd,borderRadius:12,border:`1px solid ${t.bd}`,
@@ -130,7 +132,6 @@ function _JobCard({
           <LogoImg name={j.company} size={40} t={t}/>
           <div style={JC_STYLES.titleInner}>
             <div style={JC_STYLES.titleLine}>
-              {rank != null && <span style={{fontSize:11,fontWeight:700,color:t.txM,flexShrink:0}}>#{rank}</span>}
               <span style={{fontSize:17,fontWeight:700,color:t.tx,fontFamily:"'Playfair Display',serif"}}>{j.title}</span>
               {isApplied && <Pill ch={ST_LABEL.applied} c={ST_COLOR.applied} t={t}/>}
               <Pill ch={catLbl} c={t.bl} t={t}/>
@@ -139,6 +140,13 @@ function _JobCard({
             <div className="job-meta" style={{...JC_STYLES.metaRow, color:t.txS}}>
               <span style={{fontWeight:700}}>{j.company}</span>
               {isPlatinum(j) && <span style={JC_STYLES.platinum}>PLATINUM</span>}
+              {dreamRank != null && (
+                <span style={{fontSize:11,fontWeight:700,padding:"2px 7px",borderRadius:4,
+                  background:"#b8860b18",color:"#b8860b",border:"1px solid #b8860b40",
+                  whiteSpace:"nowrap",letterSpacing:".02em"}}>
+                  ★ Dream #{dreamRank}
+                </span>
+              )}
               <span>{j._loc.display||"—"}</span>
               {j._loc.state && <span style={{color:t.bl,fontWeight:600}}>📍 {j._loc.state}</span>}
               {j._loc.isRemote && <span style={{color:t.ok,fontWeight:700}}>🏠 Remote</span>}
@@ -151,14 +159,46 @@ function _JobCard({
         </div>
         <div style={JC_STYLES.scoreCluster}>
           {fitChip}
-          <div style={{width:52,height:52,borderRadius:12,display:"flex",alignItems:"center",justifyContent:"center",background:t.sBg(sc)}}>
-            <span style={{fontSize:20,fontWeight:800,color:t.sTx(sc),fontFamily:"'Playfair Display',serif"}}>{(sc*100).toFixed(0)}%</span>
+          <div style={{display:"flex",flexDirection:"column",alignItems:"center",gap:2}}>
+            <span style={{fontSize:10,fontWeight:600,color:t.txM,textTransform:"uppercase",letterSpacing:".06em"}}>Score</span>
+            <div style={{width:52,height:52,borderRadius:12,display:"flex",alignItems:"center",justifyContent:"center",background:t.sBg(sc)}}>
+              <span style={{fontSize:20,fontWeight:800,color:t.sTx(sc),fontFamily:"'Playfair Display',serif"}}>{(sc*100).toFixed(0)}%</span>
+            </div>
           </div>
           <span style={{fontSize:18,color:t.txM,transform:open?"rotate(180deg)":"",transition:"transform .2s"}}>▾</span>
         </div>
       </div>
       {open && (
         <div style={{padding:"0 20px 18px",borderTop:`1px solid ${t.bd}`}}>
+          {/* Score breakdown panel */}
+          {(() => {
+            const rows = estimateScoreBreakdown(j);
+            const total = rows.reduce((s,r) => s + r.estPct, 0);
+            return (
+              <div style={{margin:"14px 0 12px",padding:"12px 14px",borderRadius:10,background:`${t.bd}30`,border:`1px solid ${t.bd}`}}>
+                <div style={{fontSize:11,fontWeight:700,color:t.txM,textTransform:"uppercase",letterSpacing:".06em",marginBottom:10}}>
+                  Estimated score breakdown
+                </div>
+                <div style={{display:"flex",flexDirection:"column",gap:5}}>
+                  {rows.map(row => (
+                    <div key={row.label} style={{display:"flex",alignItems:"center",gap:8,fontSize:11}}>
+                      <span style={{width:110,color:t.txM,flexShrink:0}}>{row.label}</span>
+                      <div style={{flex:1,height:6,borderRadius:3,background:`${t.bd}80`,overflow:"hidden"}}>
+                        <div style={{width:`${row.maxPct > 0 ? Math.min(100,(row.estPct/row.maxPct)*100) : 0}%`,height:"100%",background:t.ac,borderRadius:3,transition:"width .25s"}}/>
+                      </div>
+                      <span style={{width:30,textAlign:"right",fontWeight:700,color:t.tx,flexShrink:0}}>{row.estPct}%</span>
+                      <span style={{color:t.txM,flex:"0 1 140px",overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}} title={row.driver}>{row.driver}</span>
+                    </div>
+                  ))}
+                </div>
+                <div style={{marginTop:8,fontSize:11,color:t.txM,borderTop:`1px solid ${t.bd}`,paddingTop:6}}>
+                  Est. total: <strong style={{color:t.tx}}>{total}%</strong>
+                  {" "}· Stored: <strong style={{color:t.tx}}>{Math.round(sc*100)}%</strong>
+                  {" "}· <span style={{fontStyle:"italic"}}>Breakdown is an estimate; stored score is authoritative</span>
+                </div>
+              </div>
+            );
+          })()}
           <div style={JC_STYLES.skillsRow}>
             {(j.matched_skills||[]).map(s => <Pill key={s} ch={s} t={t} big/>)}
             {(j.sponsorship||likelySponsor(j)) && <Pill ch="🛂 Likely H1B" c={t.vi} t={t} big/>}

--- a/frontend/src/lib/jobConstants.js
+++ b/frontend/src/lib/jobConstants.js
@@ -100,6 +100,104 @@ export function likelySponsor(job){
   return["uber","meta","google","amazon","apple","microsoft","netflix","stripe","anthropic","openai","datadog","snowflake","databricks","two sigma","citadel","bloomberg","capital one","palantir","coinbase"].includes((job.company||"").toLowerCase());
 }
 
+// ─── Dream company ranking (41 entries, personal priority order) ─────────────
+export const DREAM_COMPANY_RANK = Object.freeze({
+  "anthropic": 1, "openai": 2, "stripe": 3, "databricks": 4, "snowflake": 5,
+  "goldman sachs": 6, "walmart": 7, "apple": 8, "nvidia": 9, "google": 10,
+  "microsoft": 11, "disney": 12, "citadel": 13, "citadel securities": 14,
+  "aqr capital": 15, "hudson river trading": 16, "jane street": 17,
+  "two sigma": 18, "jump trading": 19, "sig": 20, "imc trading": 21,
+  "bridgewater associates": 22, "flow traders": 23, "tower research capital": 24,
+  "millennium management": 25, "point72": 26, "optiver": 27,
+  "virtu financial": 28, "pimco": 29, "netflix": 30, "meta": 31,
+  "spotify": 32, "fidelity": 33, "uber": 34, "bloomberg": 35,
+  "morgan stanley": 36, "blackrock": 37, "doordash": 38, "amazon": 39,
+  "salesforce": 40, "jp morgan chase": 41,
+});
+
+export function getDreamRank(company) {
+  return DREAM_COMPANY_RANK[(company || "").toLowerCase()] ?? null;
+}
+
+// ─── Skill lists mirroring backend/core/relevance.py weights ─────────────────
+export const CORE_SKILLS = [
+  "python","sql","spark","pyspark","kafka","airflow","etl","data pipeline",
+  "data lake","data warehouse","azure","aws","databricks","delta lake","microsoft fabric",
+];
+
+export const SECONDARY_SKILLS = [
+  "docker","kubernetes","terraform","ci/cd","dbt","snowflake","redshift","bigquery",
+  "postgresql","sql server","mongodb","fastapi","flask","rest api","git","linux","bash",
+  "mlflow","mlops","machine learning","pytorch","tensorflow","scikit-learn","tableau",
+  "powerbi","looker","flink","kinesis","data mesh","numpy","pandas","scipy",
+  "quantitative","statistical modeling","backtesting",
+];
+
+// Score weights (mirrors relevance.py)
+const W = { core:0.36, secondary:0.17, title:0.15, location:0.10, experience:0.10, sponsorship:0.08, salary:0.04, platinum:0.08 };
+
+/**
+ * Estimate the contribution of each scoring component for a job row.
+ * Returns an array of rows ready to render as mini-bar breakdown.
+ * Frontend-only: uses matched_skills + job fields; never calls the backend.
+ */
+export function estimateScoreBreakdown(j) {
+  const matched = (j.matched_skills || []).map(s => s.toLowerCase());
+  const title = (j.title || "").toLowerCase();
+  const desc = (j.description || "").toLowerCase();
+  const loc = ((j._loc && j._loc.display) || j.location || "").toLowerCase();
+
+  const coreHits = CORE_SKILLS.filter(s => matched.some(m => m.includes(s)));
+  const secHits = SECONDARY_SKILLS.filter(s => matched.some(m => m.includes(s)));
+
+  const coreEst = Math.min(W.core, (coreHits.length / 15) * W.core);
+
+  const secEst = Math.min(W.secondary, (secHits.length / 35) * W.secondary);
+
+  let titleEst = 0; let titleDriver = "no match";
+  if (/data engineer/.test(title))       { titleEst = W.title;       titleDriver = "data engineer"; }
+  else if (/ml engineer|machine learning engineer/.test(title)) { titleEst = W.title * (14/15); titleDriver = "ml engineer"; }
+  else if (/quant/.test(title))          { titleEst = W.title * (13/15); titleDriver = "quant"; }
+  else if (/analytics engineer/.test(title)) { titleEst = W.title * (12/15); titleDriver = "analytics engineer"; }
+  else if (/platform engineer/.test(title))  { titleEst = W.title * (8/15);  titleDriver = "platform engineer"; }
+  else if (/engineer|scientist/.test(title)) { titleEst = W.title * (5/15);  titleDriver = "engineer/scientist"; }
+
+  let locEst = 0; let locDriver = "no match";
+  if (/remote/.test(loc) || j._loc?.isRemote) { locEst = W.location; locDriver = "remote"; }
+  else if (/dallas|austin|tx|texas/.test(loc)) { locEst = W.location * 0.8; locDriver = "TX metro"; }
+
+  let expEst = 0; let expDriver = "none";
+  const expText = title + " " + desc;
+  if (/\bstaff\b|\bprincipal\b|\blead\b/.test(expText))    { expEst = W.experience;       expDriver = "staff/principal/lead"; }
+  else if (/\bsenior\b|\bsr\.?\b/.test(expText))           { expEst = W.experience * 0.9; expDriver = "senior"; }
+  else if (/4\+\s*years|5\+\s*years/.test(expText))        { expEst = W.experience * 0.7; expDriver = "4+ years"; }
+
+  const sponsorFlag = j.sponsorship;
+  let sponsEst = 0; let sponsDriver = "neutral";
+  if (sponsorFlag === 1)  { sponsEst =  W.sponsorship; sponsDriver = "H1B positive"; }
+  else if (sponsorFlag === -1) { sponsEst = -W.sponsorship; sponsDriver = "no sponsorship"; }
+
+  let salEst = 0; let salDriver = "no salary";
+  const smax = j.salary_max || 0;
+  if (smax >= 300000)      { salEst = W.salary;       salDriver = `$${Math.round(smax/1000)}K max`; }
+  else if (smax >= 220000) { salEst = W.salary * 0.8; salDriver = `$${Math.round(smax/1000)}K max`; }
+  else if (smax >= 150000) { salEst = W.salary * 0.5; salDriver = `$${Math.round(smax/1000)}K max`; }
+
+  const platEst = isPlatinum(j) ? W.platinum : 0;
+
+  const rows = [
+    { label:"Core skills",      maxPct:36, estPct:Math.round(coreEst*100),    driver: coreHits.length ? `${coreHits.length}/15: ${coreHits.slice(0,4).join(", ")}` : "none matched" },
+    { label:"Secondary skills", maxPct:17, estPct:Math.round(secEst*100),     driver: secHits.length  ? `${secHits.length}/35: ${secHits.slice(0,3).join(", ")}` : "none matched" },
+    { label:"Title relevance",  maxPct:15, estPct:Math.round(titleEst*100),   driver: titleDriver },
+    { label:"Location",         maxPct:10, estPct:Math.round(locEst*100),     driver: locDriver },
+    { label:"Experience level", maxPct:10, estPct:Math.round(expEst*100),     driver: expDriver },
+    { label:"Sponsorship",      maxPct: 8, estPct:Math.round(sponsEst*100),   driver: sponsDriver },
+    { label:"Salary tier",      maxPct: 4, estPct:Math.round(salEst*100),     driver: salDriver },
+    { label:"Platinum boost",   maxPct: 8, estPct:Math.round(platEst*100),    driver: isPlatinum(j) ? "Tier 0 company" : "not tier 0" },
+  ];
+  return rows;
+}
+
 /**
  * JobCard's inline style record. Frozen so React.memo never gets a new
  * identity from a recompute — every card shares the same prototype.

--- a/frontend/src/tabs/JobsTab.jsx
+++ b/frontend/src/tabs/JobsTab.jsx
@@ -124,12 +124,11 @@ export function JobsTab({ state }) {
 
       {/* Job cards */}
       <div style={{display:"flex",flexDirection:"column",gap:10}}>
-        {fj.slice(0, visibleCount).map((j, idx) => {
+        {fj.slice(0, visibleCount).map(j => {
           const coKey = (j.company || "").toLowerCase();
           return (
             <JobCard
               key={j.external_id}
-              rank={idx + 1}
               j={j}
               t={t}
               open={xJ === j.external_id}


### PR DESCRIPTION
## Summary
Adds a "dream company" ranking system and frontend score breakdown visualization to help users understand how their relevance score is calculated. This makes the scoring algorithm transparent and highlights when jobs are from highly-desired companies.

## Key Changes

**jobConstants.js:**
- Added `DREAM_COMPANY_RANK` — a frozen object ranking 41 target companies by personal priority (Anthropic #1, JP Morgan Chase #41)
- Added `getDreamRank(company)` helper to look up a company's dream rank
- Added `CORE_SKILLS` and `SECONDARY_SKILLS` arrays mirroring backend relevance.py weights
- Added `estimateScoreBreakdown(j)` function that estimates the contribution of each scoring component (core skills, secondary skills, title relevance, location, experience level, sponsorship, salary, platinum boost) and returns an array of breakdown rows with percentages and driver explanations

**JobCard.jsx:**
- Imported `getDreamRank` and `estimateScoreBreakdown` from jobConstants
- Removed `rank` prop (sequential numbering) from component signature
- Replaced simple rank display with a "★ Dream #N" badge styled in gold when company matches dream ranking
- Restructured score display to include a "Score" label above the percentage circle
- Added collapsible score breakdown panel showing estimated contribution of each factor:
  - Mini horizontal bar chart for each component
  - Percentage and driver explanation (e.g., "data engineer", "remote", "4+ years")
  - Total estimated vs. stored score comparison with disclaimer that stored score is authoritative
- Breakdown panel appears when job card is expanded

**JobsTab.jsx:**
- Removed `rank={idx + 1}` prop when rendering JobCard (no longer needed since dream ranking is company-based, not position-based)

## Implementation Details

The score breakdown is **frontend-only** — it uses matched_skills and job fields already present in the card data, never calls the backend. The estimation logic mirrors the backend's relevance.py weights (core: 36%, secondary: 17%, title: 15%, location: 10%, experience: 10%, sponsorship: 8%, salary: 4%, platinum: 8%).

The dream company badge uses a subtle gold color scheme (#b8860b) to distinguish it from other UI elements, and the breakdown panel is styled to match the existing dark/light theme system.

https://claude.ai/code/session_014zk37tDmtzBp9UFSSzr6L4